### PR TITLE
fix(export): preserve formulas in table exports

### DIFF
--- a/scripts/verify-safari-resources.mjs
+++ b/scripts/verify-safari-resources.mjs
@@ -70,7 +70,7 @@ for (const { relativePath, source } of tableLatexMethodBundles) {
     nextMethodIndex === -1 ? methodNameIndex + 2000 : nextMethodIndex,
   );
 
-  if (methodFragment.includes('(?<!')) {
+  if (/\(\?<([=!])/.test(methodFragment)) {
     console.error(`${tableLatexMethodName} uses unsupported RegExp lookbehind in ${relativePath}`);
     process.exit(1);
   }

--- a/scripts/verify-safari-resources.mjs
+++ b/scripts/verify-safari-resources.mjs
@@ -43,6 +43,39 @@ function listFiles(directory, prefix = '') {
   });
 }
 
+const tableLatexMethodName = 'preserveLatexPipeCommandsInMarkdownTable';
+const tableLatexMethodBundles = listFiles(distDir)
+  .filter((relativePath) => relativePath.endsWith('.js'))
+  .map((relativePath) => ({
+    relativePath,
+    source: fs.readFileSync(path.join(distDir, relativePath), 'utf8'),
+  }))
+  .filter(({ source }) => source.includes(tableLatexMethodName));
+
+if (tableLatexMethodBundles.length === 0) {
+  console.error(`Missing ${tableLatexMethodName} in the Safari build output`);
+  process.exit(1);
+}
+
+for (const { relativePath, source } of tableLatexMethodBundles) {
+  const methodDefinition = `static ${tableLatexMethodName}`;
+  const methodNameIndex = source.indexOf(methodDefinition);
+  if (methodNameIndex === -1) {
+    console.error(`Missing ${methodDefinition} definition in ${relativePath}`);
+    process.exit(1);
+  }
+  const nextMethodIndex = source.indexOf('static ', methodNameIndex + methodDefinition.length);
+  const methodFragment = source.slice(
+    methodNameIndex,
+    nextMethodIndex === -1 ? methodNameIndex + 2000 : nextMethodIndex,
+  );
+
+  if (methodFragment.includes('(?<!')) {
+    console.error(`${tableLatexMethodName} uses unsupported RegExp lookbehind in ${relativePath}`);
+    process.exit(1);
+  }
+}
+
 const bundleResourcesDir = process.argv[2];
 if (bundleResourcesDir) {
   const missingBundleFiles = listFiles(distDir).filter(

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -55,6 +55,16 @@ type ExportCodeBlock =
   | { kind: 'mermaid'; element: HTMLElement }
   | { kind: 'code'; element: HTMLElement };
 
+interface SerializedTableCell {
+  text: string;
+  hasFormulas: boolean;
+}
+
+interface SerializedTable {
+  rows: string[][];
+  hasFormulas: boolean;
+}
+
 export class DOMContentExtractor {
   private static DEBUG = false;
   private static exportAdapter: ExportPlatformAdapter;
@@ -467,6 +477,7 @@ export class DOMContentExtractor {
         const elementToExtract = (tableBlock || child) as HTMLElement;
         const tableContent = this.extractTable(elementToExtract);
         if (this.DEBUG) console.log('[DOMContentExtractor] Table content:', tableContent.text);
+        if (tableContent.hasFormulas) flags.hasFormulas = true;
         if (tableContent.text) {
           // Only add if table was successfully extracted
           flags.hasTables = true;
@@ -701,7 +712,10 @@ export class DOMContentExtractor {
   /**
    * Process inline content (text with inline formulas)
    */
-  private static processInlineContent(element: HTMLElement): {
+  private static processInlineContent(
+    element: HTMLElement,
+    forMarkdownTable = false,
+  ): {
     html: string;
     text: string;
     hasFormulas: boolean;
@@ -717,6 +731,11 @@ export class DOMContentExtractor {
         if (text.trim()) {
           htmlParts.push(this.escapeHtml(text));
           textParts.push(text);
+        } else if (text && (htmlParts.length > 0 || textParts.length > 0)) {
+          // Whitespace-only nodes can be the only separator between adjacent
+          // inline elements, for example <strong>high</strong> <em>risk</em>.
+          htmlParts.push(' ');
+          textParts.push(' ');
         }
       } else if (node.nodeType === Node.ELEMENT_NODE) {
         const el = node as Element;
@@ -725,32 +744,52 @@ export class DOMContentExtractor {
           return;
         }
 
-        if (this.exportAdapter.extractInlineFormula(el, htmlParts, textParts)) {
+        const formulaHtmlParts: string[] = [];
+        const formulaTextParts: string[] = [];
+
+        if (this.exportAdapter.extractInlineFormula(el, formulaHtmlParts, formulaTextParts)) {
           hasFormulas = true;
+          htmlParts.push(...formulaHtmlParts);
+
+          const formulaMarkdown = formulaTextParts.join('');
+          textParts.push(
+            forMarkdownTable
+              ? this.preserveLatexPipeCommandsInMarkdownTable(formulaMarkdown)
+              : formulaMarkdown,
+          );
           return;
         }
 
         // Emphasis
         if (el.tagName === 'I' || el.tagName === 'EM') {
-          const text = this.normalizeText(el.textContent || '');
-          htmlParts.push(`<em>${this.escapeHtml(text)}</em>`);
-          textParts.push(`*${text}*`);
+          const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
+          if (processed.hasFormulas) hasFormulas = true;
+          if (processed.html || processed.text) {
+            htmlParts.push(`<em>${processed.html}</em>`);
+            textParts.push(`*${processed.text}*`);
+          }
           return;
         }
 
         // Strong
         if (el.tagName === 'B' || el.tagName === 'STRONG') {
-          const text = this.normalizeText(el.textContent || '');
-          htmlParts.push(`<strong>${this.escapeHtml(text)}</strong>`);
-          textParts.push(`**${text}**`);
+          const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
+          if (processed.hasFormulas) hasFormulas = true;
+          if (processed.html || processed.text) {
+            htmlParts.push(`<strong>${processed.html}</strong>`);
+            textParts.push(`**${processed.text}**`);
+          }
           return;
         }
 
         // Code
         if (el.tagName === 'CODE' && !el.closest('pre')) {
-          const text = this.normalizeText(el.textContent || '');
-          htmlParts.push(`<code>${this.escapeHtml(text)}</code>`);
-          textParts.push(`\`${text}\``);
+          const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
+          if (processed.hasFormulas) hasFormulas = true;
+          if (processed.html || processed.text) {
+            htmlParts.push(`<code>${processed.html}</code>`);
+            textParts.push(`\`${processed.text}\``);
+          }
           return;
         }
 
@@ -777,8 +816,8 @@ export class DOMContentExtractor {
     Array.from(element.childNodes).forEach(processNode);
 
     return {
-      html: htmlParts.join(''),
-      text: textParts.join(''),
+      html: htmlParts.join('').trim(),
+      text: textParts.join('').trim(),
       hasFormulas,
     };
   }
@@ -898,7 +937,11 @@ export class DOMContentExtractor {
   /**
    * Extract table content
    */
-  private static extractTable(element: HTMLElement): { html: string; text: string } {
+  private static extractTable(element: HTMLElement): {
+    html: string;
+    text: string;
+    hasFormulas: boolean;
+  } {
     // Accept either a container that holds a <table>, or a <table> element itself
     let table: HTMLTableElement | null = null;
     if (element.tagName && element.tagName.toLowerCase() === 'table') {
@@ -907,7 +950,7 @@ export class DOMContentExtractor {
       table = element.querySelector('table') as HTMLTableElement | null;
     }
     if (!table) {
-      return { html: '', text: '' };
+      return { html: '', text: '', hasFormulas: false };
     }
 
     // Extract HTML (clean version)
@@ -915,51 +958,78 @@ export class DOMContentExtractor {
     this.stripExportArtifacts(cleanTable);
 
     // Convert to Markdown
-    const normalizeCell = (cell: Element): string =>
-      this.normalizeText(cell.textContent || '').replace(/\|/g, '\\|');
-    const rows: string[][] = [];
+    const rowCells: Element[][] = [];
     const headerCells = Array.from(table.querySelectorAll('thead tr td, thead tr th'));
     if (headerCells.length > 0) {
-      rows.push(headerCells.map(normalizeCell));
+      rowCells.push(headerCells);
     }
 
     const bodyRows = table.querySelectorAll('tbody tr');
     bodyRows.forEach((row) => {
-      const cells = Array.from(row.querySelectorAll('td, th'));
-      rows.push(cells.map(normalizeCell));
+      rowCells.push(Array.from(row.querySelectorAll('td, th')));
     });
+    const serializedTable = this.serializeTableRows(rowCells);
 
     // Build Markdown table
     const markdownLines: string[] = [];
-    if (rows.length > 0) {
+    if (serializedTable.rows.length > 0) {
       // Header
-      markdownLines.push('| ' + rows[0].join(' | ') + ' |');
-      markdownLines.push('| ' + rows[0].map(() => '---').join(' | ') + ' |');
+      markdownLines.push('| ' + serializedTable.rows[0].join(' | ') + ' |');
+      markdownLines.push('| ' + serializedTable.rows[0].map(() => '---').join(' | ') + ' |');
       // Body
-      for (let i = 1; i < rows.length; i++) {
-        markdownLines.push('| ' + rows[i].join(' | ') + ' |');
-      }
-    } else {
-      // Fallback: treat first tbody row as header if no thead present
-      const firstBodyRow = table.querySelector('tbody tr');
-      if (firstBodyRow) {
-        const header = Array.from(firstBodyRow.querySelectorAll('td, th')).map(normalizeCell);
-        if (header.length > 0) {
-          markdownLines.push('| ' + header.join(' | ') + ' |');
-          markdownLines.push('| ' + header.map(() => '---').join(' | ') + ' |');
-          const rest = Array.from(table.querySelectorAll('tbody tr')).slice(1);
-          rest.forEach((row) => {
-            const cells = Array.from(row.querySelectorAll('td, th')).map(normalizeCell);
-            markdownLines.push('| ' + cells.join(' | ') + ' |');
-          });
-        }
+      for (let i = 1; i < serializedTable.rows.length; i++) {
+        markdownLines.push('| ' + serializedTable.rows[i].join(' | ') + ' |');
       }
     }
 
     return {
       html: cleanTable.outerHTML,
       text: markdownLines.join('\n'),
+      hasFormulas: serializedTable.hasFormulas,
     };
+  }
+
+  private static serializeTableRows(rowCells: Element[][]): SerializedTable {
+    let hasFormulas = false;
+    const rows = rowCells.map((cells) =>
+      cells.map((cell) => {
+        const serializedCell = this.serializeTableCell(cell as HTMLElement);
+        if (serializedCell.hasFormulas) hasFormulas = true;
+        return serializedCell.text;
+      }),
+    );
+
+    return { rows, hasFormulas };
+  }
+
+  private static serializeTableCell(cell: HTMLElement): SerializedTableCell {
+    const processed = this.processInlineContent(cell, true);
+
+    return {
+      text: this.escapeMarkdownTableCell(this.normalizeText(processed.text)),
+      hasFormulas: processed.hasFormulas,
+    };
+  }
+
+  /**
+   * Escape pipes before joining cells into a Markdown table row.
+   * Existing backslashes are doubled so the rendered cell preserves them while
+   * the final odd backslash still prevents the pipe from becoming a delimiter.
+   */
+  private static escapeMarkdownTableCell(text: string): string {
+    return text.replace(/(\\*)\|/g, (_match, backslashes: string) => {
+      return `${'\\'.repeat(backslashes.length * 2 + 1)}|`;
+    });
+  }
+
+  /**
+   * Keep LaTeX's `\|` double-vertical-bar command intact when the formula is
+   * embedded in a Markdown table. The table parser consumes backslashes used
+   * to escape pipes before the KaTeX extension receives the formula, so use
+   * the equivalent pipe-free command instead.
+   */
+  private static preserveLatexPipeCommandsInMarkdownTable(latex: string): string {
+    return latex.replace(/(?<!\\)\\\|/g, '\\Vert{}');
   }
 
   /**

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -482,7 +482,7 @@ export class DOMContentExtractor {
           // Only add if table was successfully extracted
           flags.hasTables = true;
           htmlParts.push(tableContent.html);
-          textParts.push(`\n${tableContent.text}\n`);
+          textParts.push(`\n${tableContent.text}\n\n`);
         }
         continue;
       }
@@ -1029,7 +1029,9 @@ export class DOMContentExtractor {
    * the equivalent pipe-free command instead.
    */
   private static preserveLatexPipeCommandsInMarkdownTable(latex: string): string {
-    return latex.replace(/(?<!\\)\\\|/g, '\\Vert{}');
+    return latex.replace(/\\+\|/g, (command) => {
+      return command === '\\|' ? '\\Vert{}' : command;
+    });
   }
 
   /**

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -65,6 +65,14 @@ interface SerializedTable {
   hasFormulas: boolean;
 }
 
+interface ProcessedInlineContent {
+  html: string;
+  text: string;
+  hasFormulas: boolean;
+  hasLeadingWhitespace: boolean;
+  hasTrailingWhitespace: boolean;
+}
+
 export class DOMContentExtractor {
   private static DEBUG = false;
   private static exportAdapter: ExportPlatformAdapter;
@@ -384,6 +392,23 @@ export class DOMContentExtractor {
     processedImageSrcs: Set<string> = new Set<string>(),
   ): void {
     const children = Array.from(container.children);
+    const appendInlineContent = (processed: ProcessedInlineContent): void => {
+      if (processed.html) {
+        htmlParts.push(`<span>${processed.html}</span>`);
+      }
+
+      if (processed.text) {
+        const previousText = textParts.at(-1) ?? '';
+        const needsLeadingSpace =
+          processed.hasLeadingWhitespace && previousText.length > 0 && !/\s$/.test(previousText);
+
+        textParts.push(
+          `${needsLeadingSpace ? ' ' : ''}${processed.text}${
+            processed.hasTrailingWhitespace ? ' ' : ''
+          }`,
+        );
+      }
+    };
     if (this.DEBUG)
       console.log(
         `[DOMContentExtractor] processNodes: ${children.length} children in`,
@@ -567,8 +592,7 @@ export class DOMContentExtractor {
         if (hasDirectText && onlyInlineChildren) {
           const processed = this.processInlineContent(child as HTMLElement);
           if (processed.hasFormulas) flags.hasFormulas = true;
-          htmlParts.push(`<span>${processed.html}</span>`);
-          textParts.push(processed.text);
+          appendInlineContent(processed);
         } else {
           this.processNodes(child, htmlParts, textParts, flags, processedImageSrcs);
         }
@@ -576,11 +600,15 @@ export class DOMContentExtractor {
       }
 
       // Leaf element with no child elements: extract text content
-      const text = this.normalizeText(child.textContent || '');
-      if (text) {
-        htmlParts.push(`<span>${this.escapeHtml(text)}</span>`);
-        textParts.push(text);
-      }
+      const rawText = child.textContent || '';
+      const text = this.normalizeText(rawText);
+      appendInlineContent({
+        html: this.escapeHtml(text),
+        text,
+        hasFormulas: false,
+        hasLeadingWhitespace: /^\s/.test(rawText),
+        hasTrailingWhitespace: /\s$/.test(rawText),
+      });
     }
   }
 
@@ -715,14 +743,35 @@ export class DOMContentExtractor {
   private static processInlineContent(
     element: HTMLElement,
     forMarkdownTable = false,
-  ): {
-    html: string;
-    text: string;
-    hasFormulas: boolean;
-  } {
+  ): ProcessedInlineContent {
     let hasFormulas = false;
     const htmlParts: string[] = [];
     const textParts: string[] = [];
+
+    const appendFormattedContent = (
+      processed: ProcessedInlineContent,
+      htmlTag: 'code' | 'em' | 'strong',
+      serializeMarkdown: (text: string) => string,
+    ): void => {
+      if (processed.hasFormulas) hasFormulas = true;
+
+      const leadingSpace = processed.hasLeadingWhitespace ? ' ' : '';
+      const trailingSpace = processed.hasTrailingWhitespace ? ' ' : '';
+      const hasBoundaryWhitespace =
+        processed.hasLeadingWhitespace || processed.hasTrailingWhitespace;
+
+      if (processed.html) {
+        htmlParts.push(`${leadingSpace}<${htmlTag}>${processed.html}</${htmlTag}>${trailingSpace}`);
+      } else if (hasBoundaryWhitespace) {
+        htmlParts.push(' ');
+      }
+
+      if (processed.text) {
+        textParts.push(`${leadingSpace}${serializeMarkdown(processed.text)}${trailingSpace}`);
+      } else if (hasBoundaryWhitespace) {
+        textParts.push(' ');
+      }
+    };
 
     // Process all child nodes including text nodes
     const processNode = (node: Node): void => {
@@ -763,33 +812,23 @@ export class DOMContentExtractor {
         // Emphasis
         if (el.tagName === 'I' || el.tagName === 'EM') {
           const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
-          if (processed.hasFormulas) hasFormulas = true;
-          if (processed.html || processed.text) {
-            htmlParts.push(`<em>${processed.html}</em>`);
-            textParts.push(`*${processed.text}*`);
-          }
+          appendFormattedContent(processed, 'em', (text) => `*${text}*`);
           return;
         }
 
         // Strong
         if (el.tagName === 'B' || el.tagName === 'STRONG') {
           const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
-          if (processed.hasFormulas) hasFormulas = true;
-          if (processed.html || processed.text) {
-            htmlParts.push(`<strong>${processed.html}</strong>`);
-            textParts.push(`**${processed.text}**`);
-          }
+          appendFormattedContent(processed, 'strong', (text) => `**${text}**`);
           return;
         }
 
         // Code
         if (el.tagName === 'CODE' && !el.closest('pre')) {
-          const processed = this.processInlineContent(el as HTMLElement, forMarkdownTable);
-          if (processed.hasFormulas) hasFormulas = true;
-          if (processed.html || processed.text) {
-            htmlParts.push(`<code>${processed.html}</code>`);
-            textParts.push(`\`${processed.text}\``);
-          }
+          const processed = this.processInlineCodeContent(el as HTMLElement);
+          appendFormattedContent(processed, 'code', (text) =>
+            this.serializeInlineCodeSpan(text, forMarkdownTable),
+          );
           return;
         }
 
@@ -815,11 +854,77 @@ export class DOMContentExtractor {
 
     Array.from(element.childNodes).forEach(processNode);
 
+    const rawHtml = htmlParts.join('');
+    const rawText = textParts.join('');
+
     return {
-      html: htmlParts.join('').trim(),
-      text: textParts.join('').trim(),
+      html: rawHtml.trim(),
+      text: rawText.trim(),
       hasFormulas,
+      hasLeadingWhitespace: /^\s/.test(rawText),
+      hasTrailingWhitespace: /\s$/.test(rawText),
     };
+  }
+
+  private static processInlineCodeContent(element: HTMLElement): ProcessedInlineContent {
+    const textParts: string[] = [];
+
+    const collectText = (node: Node): void => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        textParts.push(node.textContent || '');
+        return;
+      }
+
+      if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+      const child = node as Element;
+      if (this.shouldSkipElement(child)) return;
+
+      Array.from(child.childNodes).forEach(collectText);
+    };
+
+    Array.from(element.childNodes).forEach(collectText);
+
+    const rawText = textParts.join('');
+    const text = rawText.trim();
+
+    return {
+      html: this.escapeHtml(text),
+      text,
+      hasFormulas: false,
+      hasLeadingWhitespace: /^\s/.test(rawText),
+      hasTrailingWhitespace: /\s$/.test(rawText),
+    };
+  }
+
+  private static serializeInlineCodeSpan(text: string, forMarkdownTable = false): string {
+    const needsTableSafeHtml =
+      forMarkdownTable &&
+      (/\\+\|/.test(text) || (text.includes('|') && this.normalizeText(text) !== text));
+
+    if (needsTableSafeHtml) {
+      // Marked continues parsing Markdown inside raw inline HTML. Encode every
+      // code point so backslashes and collapsible whitespace stay literal.
+      const escapedCode = Array.from(
+        text,
+        (character) => `&#x${character.codePointAt(0)!.toString(16)};`,
+      ).join('');
+
+      return `<code>${escapedCode}</code>`;
+    }
+
+    const longestBacktickRun = (text.match(/`+/g) ?? []).reduce(
+      (longest, run) => Math.max(longest, run.length),
+      0,
+    );
+    const delimiter = '`'.repeat(longestBacktickRun + 1);
+    const needsPadding =
+      text.startsWith('`') ||
+      text.endsWith('`') ||
+      (text.startsWith(' ') && text.endsWith(' ') && text.trim() !== '');
+    const padding = needsPadding ? ' ' : '';
+
+    return `${delimiter}${padding}${text}${padding}${delimiter}`;
   }
 
   /**
@@ -1015,6 +1120,8 @@ export class DOMContentExtractor {
    * Escape pipes before joining cells into a Markdown table row.
    * Existing backslashes are doubled so the rendered cell preserves them while
    * the final odd backslash still prevents the pipe from becoming a delimiter.
+   * Inline code containing pipes is serialized without literal pipes before
+   * reaching this table-level escape.
    */
   private static escapeMarkdownTableCell(text: string): string {
     return text.replace(/(\\*)\|/g, (_match, backslashes: string) => {

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -706,6 +706,41 @@ describe('DOMContentExtractor', () => {
   });
 
   describe('Gemini Notebook table exports', () => {
+    it('ends the table block before a following paragraph', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <p>前置段落</p>
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>案例</th></tr>
+                  <tr><td>最后一行表格内容</td></tr>
+                </tbody>
+              </table>
+            </table-block>
+            <p>通过这三个例题的对比可以看出……</p>
+          </div>
+        </message-content>
+      `;
+
+      const sourceRowCount = assistant.querySelectorAll('table tr').length;
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.text).toContain('| 最后一行表格内容 |\n\n通过这三个例题的对比可以看出……');
+
+      const rendered = document.createElement('div');
+      rendered.innerHTML = marked.parse(extracted.text) as string;
+      const renderedTable = rendered.querySelector('table');
+
+      expect(renderedTable?.querySelector('tbody')?.textContent).not.toContain(
+        '通过这三个例题的对比可以看出……',
+      );
+      expect(renderedTable?.nextElementSibling?.tagName).toBe('P');
+      expect(renderedTable?.querySelectorAll('tr')).toHaveLength(sourceRowCount);
+    });
+
     it('preserves inline LaTeX and removes source chips from tables with a thead', () => {
       const assistant = document.createElement('div');
       assistant.innerHTML = `
@@ -921,6 +956,41 @@ describe('DOMContentExtractor', () => {
 
       expect(rendered.querySelector('.katex-html')?.textContent).toBe('∥x∥');
       expect(rendered.querySelector('.katex-html .newline')).toBeNull();
+    });
+
+    it('preserves consecutive LaTeX vertical-bar commands in Markdown tables', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Bars</th></tr>
+                  <tr>
+                    <td><span class="math-inline" data-math="\\|\\|">‖‖</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+      const parser = new Marked(
+        markedKatex({
+          throwOnError: false,
+          output: 'html',
+          trust: true,
+          strict: false,
+        }),
+      );
+      const rendered = document.createElement('div');
+      rendered.innerHTML = parser.parse(extracted.text) as string;
+
+      expect(extracted.text).toContain('$\\Vert{}\\Vert{}$');
+      expect(rendered.querySelector('.katex-html')?.textContent).toBe('∥∥');
     });
 
     it('recursively serializes formulas and filters sources inside formatting tags', () => {

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -1,6 +1,8 @@
 /**
  * DOMContentExtractor unit tests
  */
+import { Marked, marked } from 'marked';
+import markedKatex from 'marked-katex-extension';
 import { describe, expect, it } from 'vitest';
 
 import { resolveExportAdapter } from '@/pages/content/export/adapter/platformAdapters';
@@ -701,6 +703,264 @@ describe('DOMContentExtractor', () => {
     expect(extracted.html).toMatch(/<li[^>]*>\s*Item 2/i);
     expect(extracted.html).not.toContain('sources-carousel-inline');
     expect(extracted.html).not.toContain('mat-icon');
+  });
+
+  describe('Gemini Notebook table exports', () => {
+    it('preserves inline LaTeX and removes source chips from tables with a thead', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Case</th>
+                    <th>Statistic</th>
+                    <th>Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      Text before <span class="math-inline" data-math="X \\sim B(15, 0.9)">
+                        <span class="katex"><span class="katex-html"><span class="vlist">X∼B(15, 0.9)</span></span></span>
+                      </span> text after
+                      <sources-carousel-inline>
+                        <source-inline-chips>
+                          <source-inline-chip>
+                            <div class="source-inline-chip-container"><span>PDF</span></div>
+                          </source-inline-chip>
+                        </source-inline-chips>
+                      </sources-carousel-inline>
+                    </td>
+                    <td><span data-math="p = 0.9"><span class="katex">p=0.9</span></span></td>
+                    <td><em>Emphasis</em> and <code>inline code</code></td>
+                  </tr>
+                  <tr>
+                    <td>Multiple formulas</td>
+                    <td>
+                      <span class="math-inline" data-math="\\mu = 90">μ=90</span>
+                      and
+                      <span class="math-inline" data-math="\\sigma = 3">σ=3</span>
+                    </td>
+                    <td>
+                      Kept text
+                      <span>
+                        <sources-carousel-inline>
+                          <source-inline-chip><span>PDF+1</span></source-inline-chip>
+                        </sources-carousel-inline>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasTables).toBe(true);
+      expect(extracted.hasFormulas).toBe(true);
+      expect(extracted.text).toBe(
+        [
+          '| Case | Statistic | Notes |',
+          '| --- | --- | --- |',
+          '| Text before $X \\sim B(15, 0.9)$ text after | $p = 0.9$ | *Emphasis* and `inline code` |',
+          '| Multiple formulas | $\\mu = 90$ and $\\sigma = 3$ | Kept text |',
+        ].join('\n'),
+      );
+      expect(extracted.text).not.toContain('PDF');
+      expect(extracted.text).not.toContain('PDF+1');
+      expect(extracted.html).toContain('data-math="X \\sim B(15, 0.9)"');
+      expect(extracted.html).toContain('class="katex"');
+      expect(extracted.html).toContain('class="vlist"');
+      expect(extracted.html).not.toContain('sources-carousel-inline');
+      expect(extracted.html).not.toContain('source-inline-chip');
+    });
+
+    it('uses the same inline serialization when a tbody first row is the header', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr>
+                    <th>
+                      Parameter <span class="math-inline" data-math="\\theta">θ</span>
+                      <source-inline-chip><span>PDF</span></source-inline-chip>
+                    </th>
+                    <th>Value</th>
+                  </tr>
+                  <tr>
+                    <td>
+                      Mean <span><span data-math="\\mu">μ</span></span>
+                      <span><source-inline-chip><span>PDF+1</span></source-inline-chip></span>
+                    </td>
+                    <td>
+                      <span class="math-inline" data-math="\\bar{x} = 356.5">x̄=356.5</span>
+                      and <span class="math-inline" data-math="s = 5">s=5</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasTables).toBe(true);
+      expect(extracted.hasFormulas).toBe(true);
+      expect(extracted.text).toBe(
+        [
+          '| Parameter $\\theta$ | Value |',
+          '| --- | --- |',
+          '| Mean $\\mu$ | $\\bar{x} = 356.5$ and $s = 5$ |',
+        ].join('\n'),
+      );
+      expect(extracted.text).not.toContain('PDF');
+      expect(extracted.text).not.toContain('PDF+1');
+      expect(extracted.html).toContain('data-math="\\bar{x} = 356.5"');
+      expect(extracted.html).not.toContain('source-inline-chip');
+    });
+
+    it('preserves whitespace between adjacent formatted nodes', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Assessment</th></tr>
+                  <tr><td><strong>high</strong> <em>risk</em></td></tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.text).toBe(['| Assessment |', '| --- |', '| **high** *risk* |'].join('\n'));
+    });
+
+    it('escapes table delimiters in formulas, text, and inline code', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Formula</th><th>Text</th><th>Code</th></tr>
+                  <tr>
+                    <td><span class="math-inline" data-math="P(A|B)">P(A|B)</span></td>
+                    <td>left | right</td>
+                    <td><code>a|b</code></td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.text).toContain('| $P(A\\|B)$ | left \\| right | `a\\|b` |');
+
+      const rendered = document.createElement('div');
+      rendered.innerHTML = marked.parse(extracted.text) as string;
+      const cells = rendered.querySelectorAll('tbody tr:first-child td');
+      expect(cells).toHaveLength(3);
+      expect(Array.from(cells, (cell) => cell.textContent)).toEqual([
+        '$P(A|B)$',
+        'left | right',
+        'a|b',
+      ]);
+    });
+
+    it('preserves LaTeX vertical-bar commands through Markdown table rendering', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Norm</th></tr>
+                  <tr>
+                    <td><span class="math-inline" data-math="\\|x\\|">‖x‖</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+      const parser = new Marked(
+        markedKatex({
+          throwOnError: false,
+          output: 'html',
+          trust: true,
+          strict: false,
+        }),
+      );
+      const rendered = document.createElement('div');
+      rendered.innerHTML = parser.parse(extracted.text) as string;
+
+      expect(rendered.querySelector('.katex-html')?.textContent).toBe('∥x∥');
+      expect(rendered.querySelector('.katex-html .newline')).toBeNull();
+    });
+
+    it('recursively serializes formulas and filters sources inside formatting tags', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Strong</th><th>Emphasis</th><th>Code</th></tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        <span class="math-inline" data-math="\\theta">θ</span>
+                        <source-inline-chip><span>PDF</span></source-inline-chip>
+                      </strong>
+                    </td>
+                    <td>
+                      <em>
+                        value <span data-math="\\alpha">α</span>
+                        <source-inline-chip><span>PDF+1</span></source-inline-chip>
+                      </em>
+                    </td>
+                    <td><code>x<source-inline-chip><span>PDF</span></source-inline-chip></code></td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasFormulas).toBe(true);
+      expect(extracted.text).toContain('| **$\\theta$** | *value $\\alpha$* | `x` |');
+      expect(extracted.text).not.toContain('PDF');
+      expect(extracted.text).not.toContain('PDF+1');
+    });
   });
 
   it('preserves Gemini KaTeX radical image nodes nested in lists', () => {

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -231,6 +231,39 @@ describe('DOMContentExtractor', () => {
     expect(extracted.html).toContain('total');
   });
 
+  it.each([
+    ['<span>First <strong>bold</strong> </span><span>Second.</span>', 'First **bold** Second.'],
+    ['<span>First <strong>bold</strong></span><span> Second.</span>', 'First **bold** Second.'],
+  ])('preserves whitespace between adjacent inline containers', (content, expected) => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div>${content}</div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.text).toBe(expected);
+  });
+
+  it('does not invent whitespace between adjacent inline containers', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div><span>Hello</span><span>, world.</span></div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.text).toBe('Hello, world.');
+  });
+
   it('exports ordinary prose rendered inside an open shadow root', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `<message-content><div class="markdown"><shadow-answer></shadow-answer></div></message-content>`;
@@ -887,6 +920,181 @@ describe('DOMContentExtractor', () => {
       expect(extracted.text).toBe(['| Assessment |', '| --- |', '| **high** *risk* |'].join('\n'));
     });
 
+    it.each([
+      ['First<strong> Second</strong>', 'First **Second**'],
+      ['<strong>First </strong>Second', '**First** Second'],
+      ['First<em> Second</em>', 'First *Second*'],
+      ['<code>First </code>Second', '`First` Second'],
+    ])(
+      'moves nested formatting boundary whitespace outside Markdown markers',
+      (content, expected) => {
+        const assistant = document.createElement('div');
+        assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Content</th></tr>
+                  <tr><td>${content}</td></tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+        const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+        expect(extracted.text).toBe(['| Content |', '| --- |', `| ${expected} |`].join('\n'));
+      },
+    );
+
+    it('serializes nested display tags in inline code as plain text', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <div>Run <code><strong>npm</strong><em> install</em></code>.</div>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.text).toBe('Run `npm install`.');
+      expect(extracted.html).toContain('Run <code>npm install</code>.');
+    });
+
+    it('serializes nested display tags in table inline code as plain text', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Code</th></tr>
+                  <tr>
+                    <td>
+                      <code><strong>npm</strong><em> install|test</em><source-inline-chip>PDF</source-inline-chip></code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+      const rendered = document.createElement('div');
+      rendered.innerHTML = marked.parse(extracted.text) as string;
+
+      expect(rendered.querySelectorAll('tbody tr:first-child td')).toHaveLength(1);
+      expect(rendered.querySelector('tbody tr:first-child code')?.textContent).toBe(
+        'npm install|test',
+      );
+      expect(extracted.text).not.toContain('PDF');
+    });
+
+    it.each([
+      ['a`b', '``a`b``'],
+      ['`edge`', '`` `edge` ``'],
+      ['a``b', '```a``b```'],
+    ])('round-trips backticks in inline code spans', (content, expectedMarkdown) => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <table-block>
+              <table>
+                <tbody>
+                  <tr><th>Code</th></tr>
+                  <tr><td><code>${content}</code></td></tr>
+                </tbody>
+              </table>
+            </table-block>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+      expect(extracted.text).toContain(`| ${expectedMarkdown} |`);
+
+      const rendered = document.createElement('div');
+      rendered.innerHTML = marked.parse(extracted.text) as string;
+
+      expect(rendered.querySelector('tbody tr:first-child code')?.textContent).toBe(content);
+    });
+
+    it.each([
+      [String.raw`\|`, '<code>&#x5c;&#x7c;</code>'],
+      [String.raw`\\|`, '<code>&#x5c;&#x5c;&#x7c;</code>'],
+      ['*em*|x', '`*em*\\|x`'],
+      [
+        '[link](https://example.com)|**bold**~~gone~~',
+        '`[link](https://example.com)\\|**bold**~~gone~~`',
+      ],
+    ])(
+      'round-trips Markdown syntax and backslashes in table inline code spans',
+      (content, expectedMarkdown) => {
+        const assistant = document.createElement('div');
+        assistant.innerHTML = `
+          <message-content>
+            <div class="markdown">
+              <table-block>
+                <table>
+                  <tbody>
+                    <tr><th>Code</th></tr>
+                    <tr><td><code>${content}</code></td></tr>
+                  </tbody>
+                </table>
+              </table-block>
+            </div>
+          </message-content>
+        `;
+
+        const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+        expect(extracted.text).toContain(`| ${expectedMarkdown} |`);
+
+        const rendered = document.createElement('div');
+        rendered.innerHTML = marked.parse(extracted.text) as string;
+
+        expect(rendered.querySelectorAll('tbody tr:first-child td')).toHaveLength(1);
+        expect(rendered.querySelector('tbody tr:first-child code')?.textContent).toBe(content);
+      },
+    );
+
+    it.each(['a  |  b', 'a\t|\tb', 'a\n|\nb'])(
+      'round-trips collapsible whitespace in table inline code',
+      (content) => {
+        const assistant = document.createElement('div');
+        assistant.innerHTML = `
+          <message-content>
+            <div class="markdown">
+              <table-block>
+                <table>
+                  <tbody>
+                    <tr><th>Code</th></tr>
+                    <tr><td><code>${content}</code></td></tr>
+                  </tbody>
+                </table>
+              </table-block>
+            </div>
+          </message-content>
+        `;
+
+        const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+        const rendered = document.createElement('div');
+        rendered.innerHTML = marked.parse(extracted.text) as string;
+
+        expect(extracted.text).toContain('<code>');
+        expect(rendered.querySelectorAll('tbody tr:first-child td')).toHaveLength(1);
+        expect(rendered.querySelector('tbody tr:first-child code')?.textContent).toBe(content);
+      },
+    );
+
     it('escapes table delimiters in formulas, text, and inline code', () => {
       const assistant = document.createElement('div');
       assistant.innerHTML = `
@@ -921,6 +1129,22 @@ describe('DOMContentExtractor', () => {
         'left | right',
         'a|b',
       ]);
+
+      const katexParser = new Marked(
+        markedKatex({
+          throwOnError: false,
+          output: 'html',
+          trust: true,
+          strict: false,
+        }),
+      );
+      const katexRendered = document.createElement('div');
+      katexRendered.innerHTML = katexParser.parse(extracted.text) as string;
+
+      const formulaCell = katexRendered.querySelector('tbody tr:first-child td:first-child');
+      expect(formulaCell?.querySelector('.katex')).not.toBeNull();
+      expect(formulaCell?.querySelector('.katex-error')).toBeNull();
+      expect(formulaCell?.querySelector('.katex-html')?.textContent).toContain('P(A');
     });
 
     it('preserves LaTeX vertical-bar commands through Markdown table rendering', () => {


### PR DESCRIPTION
### Description / 描述

Gemini Notebook tables can contain rendered KaTeX formulas and inline source chips in the same cells. Conversation export previously read each table cell through `textContent`, which flattened formula semantics and included citation labels such as `PDF` and `PDF+1` in exported Markdown.

This PR routes table cells through the existing inline-content serializer so that:

- formulas use their original `data-math` LaTeX source;
- inline source chips are excluded as UI artifacts;
- emphasis, inline code, whitespace, and normal text retain their existing Markdown semantics;
- tables report `hasFormulas` when formulas occur only inside cells;
- table delimiters in formulas, text, and inline code do not create extra columns;
- inline code containing ordinary pipes remains readable Markdown, while backslash-prefixed pipes use table-safe HTML serialization to preserve literal backslashes;
- the LaTeX `\|` norm command is normalized to the pipe-free equivalent `\Vert{}` in Markdown tables, preserving the rendered double vertical bars through marked + KaTeX;
- tables are terminated with a blank line so following prose cannot be parsed as another table row;
- the LaTeX pipe normalization avoids RegExp lookbehind, preserving the Safari 15.4 minimum-version contract;
- the Safari build verifies that this export method does not reintroduce lookbehind in generated JavaScript.

The rich HTML export path still clones the original table and preserves Gemini's KaTeX DOM, so PDF/image layout primitives are not reconstructed or removed.

### Root Cause / 根因

Paragraphs and lists already used `processInlineContent`, which delegates formula extraction to the active platform adapter and skips source chips. Tables instead built Markdown from `cell.textContent`, bypassing that structured path.

The first table-delimiter fix also treated all backslashes before `|` as ordinary Markdown text. That changed `\|x\|` into a sequence that marked-katex interpreted as newline commands plus single bars. Formula and ordinary-text escaping are now handled separately, with a real marked + KaTeX rendering regression test.

The first table implementation also emitted only one newline after a Markdown table. Because the final export joins fragments without adding separators, a following paragraph could be parsed as another table row. The table block now emits a blank-line boundary.

The inline serializer also trimmed boundary whitespace before adjacent inline containers were concatenated. This could turn `First **bold** Second` into `First **bold**Second`. The serializer now carries boundary-whitespace metadata separately, keeps spaces outside Markdown formatting markers, and avoids inventing spaces before punctuation.

Finally, the initial LaTeX normalization used negative RegExp lookbehind. Voyager supports Safari 15.4+, while lookbehind was introduced in Safari 16.4, and the Safari build cannot polyfill this RegExp feature. The implementation now matches the complete backslash run and converts only an exact `\|` command without lookbehind.

### Related Issue / 相关 Issue

Fixes #916

- [x] This issue is not labeled `community-only`; it was claimed through `/claim` before implementation.

### Scope / 范围

Changed files:

- `src/features/export/services/DOMContentExtractor.ts`
- `src/features/export/services/__tests__/DOMContentExtractor.test.ts`
- `scripts/verify-safari-resources.mjs`

Non-goals:

- converting Notebook citations into footnotes or bibliography entries;
- changing table header inference;
- defining Markdown downgrade behavior for nested HTML tables or multi-row table headers;
- changing KaTeX export CSS or formula-copy behavior;
- changing extension permissions, storage, locales, or manifests;
- bumping the release version.

### Regression Coverage / 回归覆盖

`DOMContentExtractor.test.ts` now covers:

- tables with a `thead`;
- tables whose first `tbody` row acts as the header;
- inline formulas and `hasFormulas` propagation;
- nested source-chip removal;
- whitespace between adjacent formatting elements;
- leading or trailing whitespace between adjacent inline containers, without inventing whitespace before punctuation;
- leading or trailing whitespace inside strong, emphasis, and inline-code nodes, moved outside Markdown markers;
- formulas nested inside strong/emphasis elements;
- literal pipes in formulas, normal text, and inline code;
- inline-code content containing single or consecutive backticks, including CommonMark boundary padding;
- inline-code `\\|` and `\\\\|` content round-tripped through actual marked table rendering without changing the code text or column count;
- ordinary `a|b` and Markdown-like code content remain readable backtick code spans in exported Markdown;
- consecutive spaces, tabs, and newlines round-trip unchanged in table inline code containing pipes;
- Markdown emphasis, link, bold, and strikethrough syntax remains literal inside table inline code containing pipes;
- nested strong/emphasis presentation tags inside inline code are flattened to filtered plain text in prose and tables;
- actual marked + KaTeX rendering of `P(A|B)` inside a Markdown table cell;
- actual marked + KaTeX rendering of `data-math="\|x\|"` as `∥x∥`, with no KaTeX newline node;
- consecutive `\|\|` commands, confirming neither match is skipped;
- a paragraph immediately following a table, confirming it renders outside `<table>` with the original row count;
- Safari build output for the table-LaTeX method, rejecting both positive and negative RegExp lookbehind.

### Visual Proof / 可视化证据

The #916 export produced the same visible result in Chrome and Firefox on the current tested commit `0a9e8cc796c876bd9ea90db13c1d97267b3abc64`. The screenshots below show the shared representative output; the duplicate Firefox capture is omitted.

- notebook source: <img width="820" height="1165" alt="截屏2026-08-13 23 46 59" src="https://github.com/user-attachments/assets/1bb8f97f-5163-42d8-9f93-41d12d1d05c3" />

- markdown rendered: <img width="904" height="629" alt="截屏2026-08-14 02 38 43" src="https://github.com/user-attachments/assets/736dcb6c-579c-460c-952a-49674a5c550d" />

- ChatGPT Markdown export smoke test: <img width="904" height="481" alt="截屏2026-08-14 02 41 20" src="https://github.com/user-attachments/assets/ff754fac-2f71-426a-9197-5cda8088f0c6" />

### Browser Testing / 浏览器测试

Tested commit / 测试提交: `0a9e8cc796c876bd9ea90db13c1d97267b3abc64`

| Browser / version      | Scenario and result / 场景与结果                                                                                                                                                                                                                              | Evidence / 证据                                                                                                                                                        |
| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Chrome `151.0.7922.77` | Passed — Loaded `dist_chrome_dev`; reproduced #916 and exported Markdown on the current commit; formulas, citation chips, pipes, inline-container spacing, and the post-table paragraph were correct; reload/repeat passed; no new console errors.            | See the current-head representative output in [Visual Proof](#visual-proof--可视化证据)                                                                                |
| Firefox `153.0.4`      | Passed — Loaded `dist_firefox/manifest.json`; reproduced #916 and exported Markdown on the current commit; formulas, citation chips, pipes, inline-container spacing, and the post-table paragraph were correct; reload/repeat passed; no new console errors. | Shared representative output in [Visual Proof](#visual-proof--可视化证据); the Firefox result was visually identical to Chrome, so a duplicate screenshot was omitted. |
| Chrome `151.0.7922.77` | Passed — ChatGPT Markdown export smoke test on the current commit; prose, formulas, table structure, inline-container spacing, and the post-table paragraph were preserved; reload/repeat passed; no duplicate export button or new console errors.           | See the current-head ChatGPT export in [Visual Proof](#visual-proof--可视化证据)                                                                                       |

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Needs Safari Loaded + Live test; owner: @gunnlace.
- Needs Safari 15.4–16.3 compatibility test; owner: @gunnlace, unless the recorded Safari version already covers this range.
- Edge Loaded + Live was not run because this change is not Chromium-specific; GitHub CI's Edge production build passed.

Commands run and result / 已运行命令与结果:

- `bun run format` — passed.
- `bun run lint` — passed with 0 errors and 202 pre-existing warnings.
- `bun run test -- src/features/export/services/__tests__/DOMContentExtractor.test.ts` — 62 tests passed.
- `bun run verify:pr` — passed.
  - Prettier check passed.
  - ESLint check passed with the same existing warnings.
  - TypeScript check passed.
  - All 10 locales are consistent.
  - 293 test files and 2,773 tests passed.
  - Chrome, Firefox, and Safari production builds passed.
  - Safari Xcode resource wiring and table-export lookbehind checks passed.
  - VitePress documentation build passed.
- GitHub CI for `0a9e8cc796c876bd9ea90db13c1d97267b3abc64` — passed, including the Edge build and native Swift/Xcode job.
- `git diff --check` — passed.

Commands not run and reason / 未运行命令及原因:

- Local `bun run build:edge` — not required for this cross-browser content extraction change; standard PR verification excludes Edge. GitHub CI's `Build (edge)` job passed.

### Risk / 风险

Risk is limited to assistant inline-content and table serialization. The implementation reuses the existing inline-content traversal instead of adding text-based filtering, so legitimate body text such as the word `PDF` remains intact. The follow-up change preserves boundary whitespace between adjacent inline containers and moves formatting-boundary spaces outside Markdown markers. Table inline code remains readable Markdown when possible and falls back to entity-encoded HTML only when required to preserve literal backslashes or collapsible whitespace around pipes. Rich HTML table exports retain cloned KaTeX DOM nodes to avoid PDF/image layout regressions.

The Safari build check is deliberately scoped to `preserveLatexPipeCommandsInMarkdownTable`. A blanket scan would also inspect third-party lazy-loaded bundles and turn this focused fix into a dependency compatibility audit.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`, or listed every omitted command and reason above. / 我已依次运行格式化、自动修复及标准本地 `bun run verify:pr` 验证，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes, or explained why no test is useful. / 行为改动已添加或更新回归测试；若无需测试，我已说明理由。
- [x] I listed the affected browsers actually tested and identified any required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。
