### PR TITLE
fix(export): preserve whitespace-only inline separators

### DIFF
--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -393,6 +393,20 @@ export class DOMContentExtractor {
   ): void {
     const children = Array.from(container.children);
     const appendInlineContent = (processed: ProcessedInlineContent): void => {
+      const isWhitespaceOnly =
+        !processed.html &&
+        !processed.text &&
+        (processed.hasLeadingWhitespace || processed.hasTrailingWhitespace);
+
+      if (isWhitespaceOnly) {
+        const previousText = textParts.at(-1) ?? '';
+        if (previousText && !/\s$/.test(previousText)) {
+          htmlParts.push('<span> </span>');
+          textParts.push(' ');
+        }
+        return;
+      }
+
       if (processed.html) {
         htmlParts.push(`<span>${processed.html}</span>`);
       }

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -264,6 +264,22 @@ describe('DOMContentExtractor', () => {
     expect(extracted.text).toBe('Hello, world.');
   });
 
+  it('preserves a whitespace-only inline container between text containers', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div><span>First</span><span> </span><span>Second</span></div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.text).toBe('First Second');
+    expect(extracted.html).toContain('<span> </span>');
+  });
+
   it('exports ordinary prose rendered inside an open shadow root', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `<message-content><div class="markdown"><shadow-answer></shadow-answer></div></message-content>`;


### PR DESCRIPTION
## Summary

- preserve an explicit whitespace-only inline element between adjacent text containers
- keep the existing no-invented-whitespace behavior for punctuation
- add a focused regression test for the First + space + Second case

## Why

After #925 merged, a follow-up review found that an explicit whitespace-only span could be normalized to empty and dropped, exporting FirstSecond instead of First Second.

## Verification

- focused DOMContentExtractor suite: 63/63 passed
- bun run verify:pr passed
- format, lint, typecheck, i18n, full tests, Chrome/Firefox/Safari builds, Safari resource check, and docs build passed

Browser UI testing is not applicable because this is a pure export serializer fix protected by a DOM-level regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved spaces between adjacent inline text elements during Markdown export.
  * Prevented words from being unintentionally concatenated when content includes whitespace-only inline containers.
  * Preserved whitespace separators in HTML export output.

* **Tests**
  * Added regression coverage confirming whitespace preservation in Markdown and HTML exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->