### PR TITLE
fix(quote-reply): ignore Gemini greeting selections

### DIFF
--- a/src/pages/content/quoteReply/__tests__/quoteReply.test.ts
+++ b/src/pages/content/quoteReply/__tests__/quoteReply.test.ts
@@ -95,7 +95,9 @@ describe('quote reply', () => {
 
     document.body.innerHTML = `
       <main>
-        <p id="source">Hello world</p>
+        <div class="conversation-container">
+          <model-response><message-content><p id="source">Hello world</p></message-content></model-response>
+        </div>
       </main>
       <div id="input-container">
         <rich-textarea>
@@ -166,6 +168,28 @@ describe('quote reply', () => {
     triggerQuoteReply();
 
     expect(expandInputCollapseIfNeeded).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('does not show Quote Reply for Gemini new-chat greeting text', () => {
+    document.querySelector('main')!.innerHTML = '<h1>Your move, Ivaris!</h1>';
+    const greeting = document.querySelector('h1');
+    if (!(greeting?.firstChild instanceof Text)) {
+      throw new Error('Expected greeting text node.');
+    }
+
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(greeting);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const cleanup = startQuoteReply({ highlightEnabled: false });
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    vi.runAllTimers();
+
+    expect(document.querySelector('.gv-quote-btn')).toBeNull();
 
     cleanup();
   });

--- a/src/pages/content/quoteReply/__tests__/quoteReply.test.ts
+++ b/src/pages/content/quoteReply/__tests__/quoteReply.test.ts
@@ -194,6 +194,45 @@ describe('quote reply', () => {
     cleanup();
   });
 
+  it.each([
+    ['message to greeting', 'source', 'greeting'],
+    ['greeting to message', 'greeting', 'source'],
+  ])('does not show Quote Reply for a selection spanning %s', (_direction, anchorId, focusId) => {
+    document
+      .querySelector('main')!
+      .insertAdjacentHTML('afterbegin', '<h1 id="greeting">Your move, Ivaris!</h1>');
+    const anchorNode = document.getElementById(anchorId)?.firstChild;
+    const focusNode = document.getElementById(focusId)?.firstChild;
+    const greetingNode = document.getElementById('greeting')?.firstChild;
+    const sourceNode = document.getElementById('source')?.firstChild;
+    if (!(anchorNode instanceof Text) || !(focusNode instanceof Text)) {
+      throw new Error('Expected selection boundary text nodes.');
+    }
+    if (!(greetingNode instanceof Text) || !(sourceNode instanceof Text)) {
+      throw new Error('Expected ordered range boundary text nodes.');
+    }
+
+    const range = document.createRange();
+    range.setStart(greetingNode, 0);
+    range.setEnd(sourceNode, sourceNode.length);
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      anchorNode,
+      focusNode,
+      rangeCount: 1,
+      isCollapsed: false,
+      toString: () => range.toString(),
+      getRangeAt: () => range,
+    } as unknown as Selection);
+
+    const cleanup = startQuoteReply({ highlightEnabled: false });
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    vi.runAllTimers();
+
+    expect(document.querySelector('.gv-quote-btn')).toBeNull();
+
+    cleanup();
+  });
+
   it('does not blur or refocus the contenteditable input after quote insertion', () => {
     const cleanup = startQuoteReply();
     const input = document.getElementById('input');

--- a/src/pages/content/quoteReply/index.ts
+++ b/src/pages/content/quoteReply/index.ts
@@ -10,6 +10,7 @@ import {
   normalizeHighlightColorPalette,
 } from '@/core/types/highlight';
 import { getBrowserName } from '@/core/utils/browser';
+import { getAssistantTurnSelectors, getUserTurnSelectors } from '@/core/utils/selectors';
 
 import { getTranslationSync } from '../../../utils/i18n';
 import { findChatInput } from '../chatInput/index';
@@ -54,6 +55,11 @@ const EDIT_COLOR_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" heig
 const STYLE_ID = 'gemini-voyager-quote-reply-style';
 const HIGHLIGHT_PREVIEW_CLASS = 'gv-highlight-selection-preview-active';
 const HIGHLIGHT_PREVIEW_COLOR_PROPERTY = '--gv-highlight-selection-preview-color';
+const QUOTEABLE_MESSAGE_SELECTOR = [
+  '.conversation-container',
+  ...getUserTurnSelectors(),
+  ...getAssistantTurnSelectors(),
+].join(', ');
 
 function getHighlightPreviewBackground(color: HighlightColor): string {
   const hex = getHighlightColorHex(color);
@@ -1007,7 +1013,14 @@ export function startQuoteReply(options: QuoteReplyOptions = {}) {
         return;
       }
 
-      // Also check if we are selecting code block content? Might be fine.
+      // Only conversation turns are quoteable. Gemini also renders a greeting and
+      // prompt suggestions inside <main> on the new-chat screen, but those are not
+      // messages and must not expose Quote Reply.
+      if (!element?.closest(QUOTEABLE_MESSAGE_SELECTOR)) {
+        hideButton();
+        currentSelectionRange = null;
+        return;
+      }
 
       const range = selection.getRangeAt(0);
       currentSelectionRange = range.cloneRange();

--- a/src/pages/content/quoteReply/index.ts
+++ b/src/pages/content/quoteReply/index.ts
@@ -1016,13 +1016,20 @@ export function startQuoteReply(options: QuoteReplyOptions = {}) {
       // Only conversation turns are quoteable. Gemini also renders a greeting and
       // prompt suggestions inside <main> on the new-chat screen, but those are not
       // messages and must not expose Quote Reply.
-      if (!element?.closest(QUOTEABLE_MESSAGE_SELECTOR)) {
+      const range = selection.getRangeAt(0);
+      const commonAncestor =
+        range.commonAncestorContainer instanceof Element
+          ? range.commonAncestorContainer
+          : range.commonAncestorContainer.parentElement;
+      if (
+        !element?.closest(QUOTEABLE_MESSAGE_SELECTOR) ||
+        !commonAncestor?.closest(QUOTEABLE_MESSAGE_SELECTOR)
+      ) {
         hideButton();
         currentSelectionRange = null;
         return;
       }
 
-      const range = selection.getRangeAt(0);
       currentSelectionRange = range.cloneRange();
       const canHighlight =
         highlightEnabled && (highlightManager?.canCreateFromRange(range) ?? false);


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

- AI-assisted PRs are welcome, but they must be manually reviewed and verified by the contributor. / 欢迎使用 AI 辅助提交 PR，但贡献者必须亲自复核和验证。
- You are responsible for the PR's goal, scope, behavior, and verification results. You do not need to fully understand every line generated by an agent, but you should be able to explain what the PR is trying to solve and why the approach is reasonable. / 你需要为 PR 的目标、范围、行为变化和验证结果负责。你不必完全读懂 Agent 生成的每一行代码，但应该能说明这个 PR 要解决什么，以及为什么这个方案合理。
- Before coding, discuss the requirement with your agent clearly: expected behavior, affected pages/features, and how to verify it. / 开始改代码前，请先和 Agent 讨论清楚需求：预期行为、影响范围，以及如何验证。
- If you work with an AI agent (Claude Code, Codex, …), tell it to use the voyager-contribute skill bundled in this repo. / 如果你使用 AI Agent（Claude Code、Codex 等），请让它使用仓库自带的 voyager-contribute skill。
- Keep the PR focused: one PR should fix one issue or make one coherent change. / 保持 PR 聚焦：一个 PR 只修一个问题，或只做一个清晰完整的改动。
- After changing code, manually use the feature yourself. For UI/behavior changes, please spend about 15 minutes trying the real workflow when possible. / 改完后请亲自手动体验。涉及 UI 或行为变化时，条件允许的话请用真实流程体验约 15 分钟。
- Provide visual proof after verification: screenshots, screen recordings, or before/after clips. / 验证后请提供可视化证据：截图、录屏或前后对比。

---

### Description / 描述

This PR fixes #926, where Voyager displayed Quote Reply for Gemini's new-chat greeting/zero-state text. The selection handler now requires selected text to be inside known Gemini user or assistant conversation-turn selectors, reusing the repository's centralized selector definitions. A regression test covers the current greeting structure.

Tested commit / 测试提交: 08854dcf70323044ee22ba8332d4e9067ff3434e

### Related Issue / 相关 Issue

Fixes #926

- [x] N/A — #926 is a bug issue, not labeled community-only or enhancement. / N/A——#926 是 bug issue，没有 community-only 或 enhancement 标签。

### Visual Proof / 可视化证据

The screenshot below is the Chrome Live evidence: the Gemini greeting is selected while the Quote Reply toolbar is absent. / 下方截图是 Chrome Live 验证证据：Gemini 寒暄语已被选中，但 Quote Reply 工具栏没有出现。

<img width="1468" height="880" alt="Chrome Live verification: selected Gemini greeting without Quote Reply toolbar" src="https://github.com/user-attachments/assets/070ebed8-7c13-4ec2-b276-35395ca28ae9" />

### Browser Testing / 浏览器测试

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome 151.0.7922.110 | Loaded local dist_chrome in the connected Chrome session, selected “Hi Ivaris, what's the move?” on Gemini's new-chat page, and confirmed the selection remained active without .gv-selection-toolbar or .gv-quote-btn. / 在连接的 Chrome 会话中加载本地 dist_chrome，在 Gemini 新建聊天页选中寒暄语，并确认选区保留且没有 .gv-selection-toolbar 或 .gv-quote-btn。 | [Chrome Live evidence](https://github.com/user-attachments/assets/070ebed8-7c13-4ec2-b276-35395ca28ae9) |

Tested commit / 测试提交: 08854dcf70323044ee22ba8332d4e9067ff3434e

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Firefox Live verification — owner: ivaris03; no Firefox browser session is available in this environment. / Firefox Live 验证——负责人：ivaris03；当前环境没有可用的 Firefox 浏览器会话。
- Maintainer review — owner: Nagi-ovo/voyager maintainers; PR remains draft. / 维护者评审——负责人：Nagi-ovo/voyager 维护者；PR 仍为 draft。

Commands not run and reason / 未运行命令及原因:

- No additional commands were omitted.
- bun run verify:pr was run but stopped at the local Windows AGENTS.md symlink-pointer final-newline check before later gates; remote CI passed the applicable gates. / bun run verify:pr 已运行，但在本地 Windows 环境的 AGENTS.md symlink 指针末尾换行检查处停止；远端 CI 的适用检查已通过。
- Local bun run test completed with one unrelated release privacy baseline failure concerning embedded.provisionprofile filenames; the targeted quote-reply tests and remote Test job passed. / 本地 bun run test 完成时有一个与本修复无关的 release privacy 基线失败，涉及 embedded.provisionprofile 文件名；引用回复定向测试和远端 Test job 均通过。

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran bun run format, bun run lint, then the standard local bun run verify:pr, or listed every omitted command and reason above. / 我已依次运行格式化、自动修复及标准本地 bun run verify:pr 验证，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes, or explained why no test is useful. / 行为改动已添加或更新回归测试；若无需测试，我已说明理由。
- [x] I listed the affected browsers actually tested and identified any required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Quote Reply now appears only when text is selected entirely within a recognized conversation message.
  - Prevented Quote Reply from appearing for Gemini’s new-chat greeting or selections spanning the greeting and a message.
  - Improved support for quoting text from user and assistant conversation turns.

- **Tests**
  - Added coverage for Gemini’s new-chat greeting behavior and updated conversation markup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->