### PR TITLE
docs: add DeepSeek Harness runtime handbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Add any site in the extension popup and the Prompt Manager follows you there, lo
   <img src="docs/public/assets/prompt-manager-deepseek-harness.png" alt="Prompt Manager running inside DeepSeek Harness" width="720">
 </p>
 
+For source-backed DeepSeek Harness runtime troubleshooting beyond the extension layer, see the independent [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) and its [hosted field guide](https://sandbaseai.github.io/deepseek-harness-handbook/).
+
 ### 🎨 Personalization
 
 - Open the extension popup and find **Visual Effects** to switch between `Off`, `Snow`, `Sakura`, and `Rain`.


### PR DESCRIPTION
## Summary

- Add the independent DeepSeek Harness Handbook below Voyager's DeepSeek Harness integration example.
- Link the repository and hosted field guide for runtime troubleshooting beyond the browser extension layer.

This is a one-paragraph documentation-only change; no extension code or behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance linking to the DeepSeek Harness Handbook and hosted field guide for source-backed runtime troubleshooting beyond the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->