### PR TITLE
fix: resolve oxlint correctness findings and gate CI on them

### DIFF
--- a/.github/docs/regressions/rendering-export.md
+++ b/.github/docs/regressions/rendering-export.md
@@ -149,3 +149,21 @@ output.
 - **Guard:** `src/features/formulaCopy/FormulaCopyService.test.ts`
   (`copies current ChatGPT block KaTeX from data-math-source without MathML` and
   `copies current ChatGPT inline KaTeX from data-math-source as inline LaTeX`).
+
+## Zero-width sanitising must not strip the emoji joiner
+
+- **Trap:** Mermaid diagram labels containing a composed emoji rendered as its separate glyphs --
+  `👨‍👩‍👦` came out as `👨👩👦`, `🏳️‍🌈` as `🏳️🌈`. `normalizeWhitespace` strips zero-width
+  characters so stray invisibles from model output cannot break the parser, and U+200D sat in that
+  character class alongside U+200B and U+200C. But U+200D is the zero-width _joiner_: it is what
+  holds an emoji sequence together, so removing every occurrence splits the sequence. The rule that
+  surfaced it (`no-misleading-character-class`) had never been enabled under the old ESLint config,
+  which extended no recommended set.
+- **Rule:** Strip U+200D only when it is not joining two emoji, checking the neighbouring code
+  points and skipping variation selectors and skin-tone modifiers on the way back. Walk the string
+  with `Array.from`, never by UTF-16 index, so astral emoji stay in one piece. The other zero-width
+  characters keep their unconditional removal.
+- **Guard:** `src/pages/content/mermaid/__tests__/mermaid.test.ts`
+  (`should keep the joiner that holds an emoji sequence together`,
+  `should still remove a joiner that only touches an emoji on one side`, and the original
+  `should remove zero-width joiner`, which pins the stray-joiner case that motivated the strip).

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,8 +24,16 @@
   ],
   "rules": {
     "react/rules-of-hooks": "error",
+    // Deliberately left below the category. The React team ships this one as a
+    // warning because it cannot see through refs or stable dispatch identities,
+    // and a false positive here should not be able to block a build.
     "react/exhaustive-deps": "warn",
-    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    // An explicit severity outranks the category, so this has to say "error" to
+    // inherit it. Leaving it at "warn" is how the orphaned five-function chain in
+    // export/index.ts survived: eslint had been reporting it for as long as the
+    // rule existed, and a warning nobody reads stops anything from accumulating.
+    // Prefix a binding with _ when it is genuinely meant to stay unused.
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "typescript/no-explicit-any": "warn",
     "no-console": ["warn", { "allow": ["warn", "error"] }],
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,6 +3,9 @@
   "plugins": ["typescript", "unicorn", "oxc", "react", "jsx-a11y"],
   "env": { "browser": true, "builtin": true },
   "settings": { "react": { "version": "19.1.0" } },
+  // Everything oxlint classes as outright wrong blocks CI. The three opt-outs
+  // below are the rules whose every hit in this repository was a false positive.
+  "categories": { "correctness": "error" },
   "ignorePatterns": [
     "dist_*/**",
     "output/**",
@@ -24,6 +27,19 @@
     "react/exhaustive-deps": "warn",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "typescript/no-explicit-any": "warn",
-    "no-console": ["warn", { "allow": ["warn", "error"] }]
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+
+    // All 11 hits were correct ARIA where the suggested element is not a drop-in:
+    // role="dialog" on popovers that never call showModal(), role="progressbar"
+    // on a Tailwind-styled div, role="button" on a card that contains its own
+    // <button> (nesting a real button inside another is invalid HTML).
+    "jsx-a11y/prefer-tag-over-role": "off",
+    // Fires on every "load state on mount" effect. Extension storage reads are
+    // async, so neither alternative the rule suggests -- derive during render,
+    // initialise state directly -- can express them.
+    "react/set-state-in-effect": "off",
+    // `new Array(n).fill(x)` is the codebase's preallocation idiom in layout hot
+    // paths; Array.from({length: n}) allocates more for no readability gain.
+    "unicorn/no-new-array": "off"
   }
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,5 +41,13 @@
     // `new Array(n).fill(x)` is the codebase's preallocation idiom in layout hot
     // paths; Array.from({length: n}) allocates more for no readability gain.
     "unicorn/no-new-array": "off"
-  }
+  },
+  "overrides": [
+    {
+      // Repository tooling, never bundled into the extension. Printing to the
+      // terminal is what these scripts are for.
+      "files": ["scripts/**"],
+      "rules": { "no-console": "off" }
+    }
+  ]
 }

--- a/scripts/community-issue-policy.cjs
+++ b/scripts/community-issue-policy.cjs
@@ -105,7 +105,7 @@ async function assignIssue({ github, context, username, approvedBy }) {
       ...issueParams(context),
       assignees: [username],
     });
-  } catch (error) {
+  } catch {
     await comment({
       github,
       context,

--- a/scripts/generate-sponsors.cjs
+++ b/scripts/generate-sponsors.cjs
@@ -19,7 +19,6 @@ const ROOT = path.resolve(__dirname, '..');
 const FRIENDS_PATH = path.join(ROOT, 'sponsorkit', 'sponsors.json');
 const OUTPUT_DIR = path.join(ROOT, 'docs', 'public', 'assets');
 const OUTPUT_PATH = path.join(OUTPUT_DIR, 'sponsors.svg');
-const OUTPUT_PNG_PATH = path.join(OUTPUT_DIR, 'sponsors.png');
 const SPONSORS_URL = 'https://github.com/sponsors/Nagi-ovo';
 const OWNER_LOGIN = 'Nagi-ovo';
 const GRAPHQL_ENDPOINT = 'https://api.github.com/graphql';
@@ -359,7 +358,7 @@ async function avatarDataUri(url) {
 }
 
 async function embedAvatarData(sponsors) {
-  const results = await Promise.allSettled(
+  await Promise.allSettled(
     sponsors.map(async (sponsor) => {
       if (!sponsor.avatarUrl) return;
       sponsor.avatar = await avatarDataUri(sponsor.avatarUrl);

--- a/scripts/oxc-toolchain.test.js
+++ b/scripts/oxc-toolchain.test.js
@@ -90,7 +90,32 @@ export function Probe({ flag }: { flag: boolean }) {
 
   it('keeps the jsx-a11y plugin enabled', () => {
     // jsx-a11y is off by default, so this fires only while `plugins` lists it.
-    expect(severityOf('jsx-a11y(alt-text)')).toEqual(['warning']);
+    // It reports as an error because alt-text is a correctness rule.
+    expect(severityOf('jsx-a11y(alt-text)')).toEqual(['error']);
+  });
+});
+
+describe('oxlint fails the build on the correctness category', () => {
+  it('reports a rule the config never names as an error, not a warning', () => {
+    // no-unreachable is absent from `rules`, so its severity comes entirely from
+    // `categories`. Drop that key and every correctness rule silently falls back
+    // to a warning: the lint job keeps exiting 0 and stops guarding anything.
+    const filePath = writeFixture(
+      'correctness.ts',
+      'export function dead(): number {\n  return 1;\n  console.warn("unreachable");\n}\n',
+    );
+
+    const result = spawnSync(oxlintBin, ['-c', oxlintConfig, '-f', 'json', filePath], {
+      encoding: 'utf8',
+    });
+    const payload = JSON.parse(result.stdout);
+    const unreachable = (payload.diagnostics ?? payload).filter(
+      (entry) => entry.code === 'eslint(no-unreachable)',
+    );
+
+    expect(unreachable.map((entry) => entry.severity)).toEqual(['error']);
+    // An error has to be a non-zero exit, or CI would never notice it.
+    expect(result.status).not.toBe(0);
   });
 });
 

--- a/scripts/oxc-toolchain.test.js
+++ b/scripts/oxc-toolchain.test.js
@@ -117,6 +117,30 @@ describe('oxlint fails the build on the correctness category', () => {
     // An error has to be a non-zero exit, or CI would never notice it.
     expect(result.status).not.toBe(0);
   });
+
+  it('fails on an unused binding, which an explicit severity can silently exempt', () => {
+    // no-unused-vars carries options, so it has to name a severity, and that
+    // severity outranks the category. Written as "warn" it drops out of the gate
+    // without anything else changing -- which is how a five-function dead chain
+    // survived in export/index.ts.
+    const filePath = writeFixture(
+      'unused.ts',
+      'export function keep(): number {\n  const unused = 1;\n  const _ignored = 2;\n  return 3;\n}\n',
+    );
+
+    const result = spawnSync(oxlintBin, ['-c', oxlintConfig, '-f', 'json', filePath], {
+      encoding: 'utf8',
+    });
+    const payload = JSON.parse(result.stdout);
+    const unused = (payload.diagnostics ?? payload).filter(
+      (entry) => entry.code === 'eslint(no-unused-vars)',
+    );
+
+    // Only the plain binding: the _-prefixed one stays exempt.
+    expect(unused).toHaveLength(1);
+    expect(unused[0].severity).toBe('error');
+    expect(result.status).not.toBe(0);
+  });
 });
 
 describe('oxfmt reproduces the prettier import ordering', () => {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -25,6 +25,7 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
+    // oxlint-disable-next-line jsx-a11y/heading-has-content -- primitive: consumers supply the heading text as children
     <h3
       ref={ref}
       className={cn('text-foreground/60 text-xs font-bold tracking-widest uppercase', className)}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils';
 
 const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
   ({ className, ...props }, ref) => (
+    // oxlint-disable-next-line jsx-a11y/label-has-associated-control -- primitive: consumers supply htmlFor and the control
     <label
       ref={ref}
       className={cn(

--- a/src/features/export/services/ImageRenderService.ts
+++ b/src/features/export/services/ImageRenderService.ts
@@ -15,6 +15,7 @@ const WOFF2_SOURCE_RE = /url\((["']?)([^"')]+)\1\)\s*format\((["']?)woff2\3\)/i;
  * html-to-image serializes DOM into SVG (XML 1.0). Control characters outside the legal set
  * cause the serialization to fail silently (img error Event).
  */
+// oxlint-disable-next-line no-control-regex -- matching control characters is the point; see the XML 1.0 reference above
 const XML_ILLEGAL_CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;
 
 function setStyle(element: HTMLElement | SVGElement, property: string, value: string): void {

--- a/src/features/plugins/builtin/claudeUsage/observer.test.ts
+++ b/src/features/plugins/builtin/claudeUsage/observer.test.ts
@@ -13,6 +13,7 @@ type ClaudeUsageWindow = Window &
   };
 
 function installObserver(): void {
+  // oxlint-disable-next-line no-eval -- evaluating the observer under test is what this suite exercises
   (0, eval)(observerScript);
 }
 

--- a/src/features/plugins/runtime/declarativeEngine.ts
+++ b/src/features/plugins/runtime/declarativeEngine.ts
@@ -207,6 +207,7 @@ export class DeclarativeEngine {
   }
 
   unmountAll(): void {
+    // oxlint-disable-next-line unicorn/no-useless-spread -- snapshot: the loop body mutates the collection
     for (const id of [...this.active.keys()]) this.unmount(id);
     this.doc.getElementById(PLUGIN_BASE_STYLE_ID)?.remove();
   }

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -118,7 +118,10 @@ const RESPONSE_COMPLETE_NOTIFICATION_ICON = 'icon-128.png';
 const RESPONSE_COMPLETE_NOTIFICATION_ID_PREFIX = 'gv-response-complete-';
 const RESPONSE_COMPLETE_UNKNOWN_TAB_ID = 'unknown';
 const GENERATED_UI_CAPTURE_PERMISSION_ORIGINS = ['<all_urls>'];
+// Anchored to the start, so it only strips leading invisible characters and can
+// never split an emoji sequence in the label body.
 const RESPONSE_COMPLETE_TURN_LABEL_PREFIXES =
+  // oxlint-disable-next-line no-misleading-character-class
   /^[\u200B\u200C\u200D\u200E\u200F\uFEFF]*(?:you said|you wrote|user message|your prompt|you asked)[:\s]*/i;
 const RETIRED_TAB_TITLE_UPDATE_SETTING = { [StorageKeys.TAB_TITLE_UPDATE_ENABLED]: false };
 

--- a/src/pages/content/codeBlockCollapse/index.ts
+++ b/src/pages/content/codeBlockCollapse/index.ts
@@ -139,6 +139,7 @@ export function enhanceCodeBlock(host: HTMLElement): void {
 }
 
 function cleanupDisconnectedBlocks(): void {
+  // oxlint-disable-next-line unicorn/no-useless-spread -- snapshot: the loop body mutates the collection
   for (const host of [...observedBlocks]) {
     if (host.isConnected) continue;
     resizeObserver?.unobserve(host);
@@ -209,6 +210,7 @@ export function stopCodeBlockCollapse(): void {
   }
   pendingBlocks.clear();
   observedBlocks.clear();
+  // oxlint-disable-next-line unicorn/no-useless-spread -- snapshot: the loop body mutates the collection
   for (const host of [...managedBlocks]) removeEnhancement(host);
   if (languageChangeListener) {
     try {

--- a/src/pages/content/echarts/index.ts
+++ b/src/pages/content/echarts/index.ts
@@ -511,7 +511,7 @@ export const parseEChartsOption = async (code: string): Promise<Record<string, u
   if (!code) return null;
   const cleaned = stripEChartsAssignment(code);
 
-  const [JSON5Mod] = await Promise.all([import('json5')]);
+  const JSON5Mod = await import('json5');
   const parse = JSON5Mod.default?.parse ?? JSON5Mod.parse;
 
   try {

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -841,27 +841,6 @@ async function loadDictionaries(): Promise<Record<AppLanguage, Record<string, st
   }
 }
 
-/**
- * Extract human-readable conversation title from the current page
- * Used for JSON/Markdown metadata so all formats share the same title.
- * Mirrors the logic used by PDFPrintService.getConversationTitle.
- */
-function isMeaningfulConversationTitle(title: string | null | undefined): title is string {
-  const t = (title || '').trim();
-  if (!t) return false;
-  if (
-    t === 'Untitled Conversation' ||
-    t === 'Gemini' ||
-    t === 'Google Gemini' ||
-    t === 'Google AI Studio' ||
-    t === 'New chat'
-  ) {
-    return false;
-  }
-  if (t.startsWith('Gemini -') || t.startsWith('Google AI Studio -')) return false;
-  return true;
-}
-
 function extractConversationIdFromUrl(): string | null {
   const appMatch = window.location.pathname.match(/\/app\/([^/?#]+)/);
   if (appMatch?.[1]) return appMatch[1];
@@ -882,93 +861,6 @@ function extractConversationIdFromHref(href: string): string | null {
   } catch {
     return null;
   }
-}
-
-function isGemLabel(text: string | null | undefined): boolean {
-  const t = (text || '').trim().toLowerCase();
-  return t === 'gem' || t === 'gems';
-}
-
-function extractTitleFromLinkText(link?: HTMLAnchorElement | null): string | null {
-  if (!link) return null;
-  const text = (link.innerText || '').trim();
-  if (!text) return null;
-  const parts = text
-    .split('\n')
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .filter((s) => !isGemLabel(s))
-    .filter((s) => s.length >= 2);
-  if (parts.length === 0) return null;
-  return parts.reduce((a, b) => (b.length > a.length ? b : a), parts[0]) || null;
-}
-
-function extractTitleFromConversationElement(conversationEl: HTMLElement): string | null {
-  const scope =
-    (conversationEl.closest('[data-test-id="conversation"]') as HTMLElement) || conversationEl;
-  const bySelector = scope.querySelector(
-    '.gds-label-l, .conversation-title-text, [data-test-id="conversation-title"], h3',
-  );
-  const selectorTitle = bySelector?.textContent?.trim();
-  if (isMeaningfulConversationTitle(selectorTitle) && !isGemLabel(selectorTitle)) {
-    return selectorTitle;
-  }
-
-  const link = scope.querySelector(
-    'a[href*="/app/"], a[href*="/gem/"]',
-  ) as HTMLAnchorElement | null;
-  const ariaTitle = link?.getAttribute('aria-label')?.trim();
-  if (isMeaningfulConversationTitle(ariaTitle) && !isGemLabel(ariaTitle)) {
-    return ariaTitle;
-  }
-  const linkTitle = link?.getAttribute('title')?.trim();
-  if (isMeaningfulConversationTitle(linkTitle) && !isGemLabel(linkTitle)) {
-    return linkTitle;
-  }
-  const fromLinkText = extractTitleFromLinkText(link);
-  if (isMeaningfulConversationTitle(fromLinkText)) {
-    return fromLinkText;
-  }
-
-  const label = scope.querySelector('.gds-body-m, .gds-label-m, .subtitle');
-  const labelText = label?.textContent?.trim();
-  if (isMeaningfulConversationTitle(labelText) && !isGemLabel(labelText)) {
-    return labelText;
-  }
-
-  const raw = scope.textContent?.trim() || '';
-  if (!raw) return null;
-  const firstLine =
-    raw
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean)[0] || raw;
-  if (isMeaningfulConversationTitle(firstLine) && !isGemLabel(firstLine)) {
-    return firstLine.slice(0, 80);
-  }
-
-  return null;
-}
-
-function extractTitleFromNativeSidebarByConversationId(conversationId: string): string | null {
-  const escapedConversationId = escapeCssAttributeValue(conversationId);
-  const byJslog = document.querySelector(
-    `[data-test-id="conversation"][jslog*="c_${escapedConversationId}"]`,
-  ) as HTMLElement | null;
-  if (byJslog) {
-    const title = extractTitleFromConversationElement(byJslog);
-    if (title) return title;
-  }
-
-  const byHrefLink = document.querySelector(
-    `[data-test-id="conversation"] a[href*="${escapedConversationId}"]`,
-  ) as HTMLElement | null;
-  if (byHrefLink) {
-    const title = extractTitleFromConversationElement(byHrefLink);
-    if (title) return title;
-  }
-
-  return null;
 }
 
 function escapeCssAttributeValue(value: string): string {

--- a/src/pages/content/export/platformConversationDom.ts
+++ b/src/pages/content/export/platformConversationDom.ts
@@ -5,7 +5,7 @@
  * container, falling back to `document.body`.
  */
 import type { ExportPlatformAdapter } from './adapter/platformAdapters';
-import { filterOutDeepResearchImmersiveNodes, resolveConversationRoot } from './conversationDom';
+import { resolveConversationRoot } from './conversationDom';
 
 /**
  * Resolve the conversation root element for the current platform.

--- a/src/pages/content/export/responseActionImageButton.ts
+++ b/src/pages/content/export/responseActionImageButton.ts
@@ -7,7 +7,6 @@ export type ResponseActionCopyImageOptions = {
 const COPY_BUTTON_TEST_ID = 'copy-button';
 const MORE_BUTTON_TEST_ID = 'more-menu-button';
 const COPY_IMAGE_BUTTON_TEST_ID = 'gv-copy-image-button';
-const COPY_IMAGE_ICON_NAME = 'image';
 const COPY_ICON_NAME = 'content_copy';
 const COPY_BUTTON_ARIA_PATTERNS = [/^copy\b/i, /复制/];
 const ACTION_BUTTON_SELECTOR = 'button, gem-icon-button, [role="button"]';

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -10031,6 +10031,7 @@ export class FolderManager {
       this.tooltipElement.style.top = `${top}px`;
 
       // Trigger reflow for animation
+      // oxlint-disable-next-line no-unused-expressions -- reading offsetHeight flushes layout; the value is intentionally discarded
       this.tooltipElement.offsetHeight;
       this.tooltipElement.classList.add('show');
     }, 200);

--- a/src/pages/content/fork/index.ts
+++ b/src/pages/content/fork/index.ts
@@ -373,6 +373,7 @@ function getConversationTitle(): string {
 function sanitizeFilenamePart(value: string): string {
   const cleaned = value
     .trim()
+    // oxlint-disable-next-line no-control-regex -- control characters are illegal in filenames and must be matched to be stripped
     .replace(/[\\/:*?"<>|\u0000-\u001f]+/g, '-')
     .replace(/\s+/g, ' ')
     .slice(0, 80)

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable no-unsafe-optional-chaining -- `mermaid?.render` is undefined only when
+   loadMermaid() failed, and letting that throw is how these tests report it. */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -654,6 +656,24 @@ B --> C`;
     it('should remove zero-width joiner', () => {
       const input = 'graph\u200DTD';
       expect(normalizeWhitespace(input)).toBe('graphTD');
+    });
+
+    it('should keep the joiner that holds an emoji sequence together', () => {
+      // Stripping every U+200D splits these into their component glyphs, so a
+      // node label like `A["\u{1F468}\u200D\u{1F469}\u200D\u{1F466} team"]`
+      // would render as three separate people.
+      const family = '\u{1F468}\u200D\u{1F469}\u200D\u{1F466}';
+      expect(normalizeWhitespace(family)).toBe(family);
+
+      // The flag sequence puts a variation selector between the emoji and the
+      // joiner, so the lookback has to skip it.
+      const flag = '\u{1F3F3}\uFE0F\u200D\u{1F308}';
+      expect(normalizeWhitespace(flag)).toBe(flag);
+    });
+
+    it('should still remove a joiner that only touches an emoji on one side', () => {
+      expect(normalizeWhitespace('a\u200D\u{1F44D}')).toBe('a\u{1F44D}');
+      expect(normalizeWhitespace('\u{1F44D}\u200Db')).toBe('\u{1F44D}b');
     });
 
     it('should remove BOM character', () => {

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -655,13 +655,40 @@ export const _openFullscreenForTest = openFullscreen;
 /**
  * @internal Exported for testing
  */
+const PICTOGRAPHIC = /\p{Extended_Pictographic}/u;
+/** Variation selectors and skin-tone modifiers sit between an emoji and its joiner. */
+const EMOJI_MODIFIER = /\uFE0F|\p{Emoji_Modifier}/u;
+
+/**
+ * A zero-width joiner is only meaningful when it actually joins two emoji, as in
+ * a family or flag sequence. Anywhere else it is invisible noise that breaks the
+ * Mermaid parser, so it should be stripped like the other zero-width characters.
+ */
+const joinsEmoji = (source: string, index: number): boolean => {
+  // Array.from splits by code point, so an astral emoji stays in one piece.
+  const before = Array.from(source.slice(0, index));
+  let previous = before.pop();
+  while (previous !== undefined && EMOJI_MODIFIER.test(previous)) previous = before.pop();
+  const next = Array.from(source.slice(index + 1))[0];
+  return (
+    previous !== undefined &&
+    next !== undefined &&
+    PICTOGRAPHIC.test(previous) &&
+    PICTOGRAPHIC.test(next)
+  );
+};
+
 export const normalizeWhitespace = (code: string): string => {
   return (
     code
       // Replace various special space characters with standard space
       .replace(/[\u00A0\u2002\u2003\u2009\u3000]/g, ' ')
       // Remove zero-width characters that can cause issues
-      .replace(/[\u200B\u200C\u200D\uFEFF]/g, '')
+      .replace(/[\u200B\u200C\uFEFF]/g, '')
+      // Strip stray joiners, but keep the ones holding an emoji sequence together
+      .replace(/\u200D/gu, (match, index: number, source: string) =>
+        joinsEmoji(source, index) ? match : '',
+      )
   );
 };
 

--- a/src/pages/content/prompt/index.ts
+++ b/src/pages/content/prompt/index.ts
@@ -184,7 +184,6 @@ function navigateToSavedLibraryItem(item: SavedLibraryItem): boolean {
       : new Event('popstate'),
   );
   return true;
-  window.dispatchEvent(new Event('hashchange'));
 }
 
 function detectPageTheme(): PMTheme {
@@ -1623,8 +1622,7 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
       const selectedTagList = Array.from(selectedTags);
       const nameConflictIds = getPromptNameConflictIds(items);
       const filtered = items.filter((it) => {
-        const okTag =
-          selectedTagList.length === 0 || selectedTagList.every((t) => it.tags.includes(t));
+        const okTag = selectedTagList.every((t) => it.tags.includes(t));
         if (!okTag) return false;
         if (!q) return true;
         // Include the user-authored name so searching for the label shown in

--- a/src/pages/content/responseNotification/__tests__/pageObserver.test.ts
+++ b/src/pages/content/responseNotification/__tests__/pageObserver.test.ts
@@ -8,6 +8,7 @@ const SOURCE = 'gemini-voyager-response-complete-observer';
 const NativeXMLHttpRequest = window.XMLHttpRequest;
 
 function installObserver(): void {
+  // oxlint-disable-next-line no-eval -- evaluating the observer under test is what this suite exercises
   (0, eval)(observerScript);
 }
 

--- a/src/pages/content/responseNotification/index.ts
+++ b/src/pages/content/responseNotification/index.ts
@@ -30,7 +30,10 @@ const MAX_NOTIFICATION_PROMPT_LENGTH = 140;
 const LATEST_RESPONSE_VISIBLE_MARGIN_PX = 96;
 const BOTTOM_SCROLL_THRESHOLD_PX = 160;
 const PROMPT_SELECTORS = 'rich-textarea, textarea, [contenteditable="true"], div[role="textbox"]';
+// Anchored to the start, so it only strips leading invisible characters and can
+// never split an emoji sequence in the label body.
 const TURN_LABEL_PREFIXES =
+  // oxlint-disable-next-line no-misleading-character-class
   /^[\u200B\u200C\u200D\u200E\u200F\uFEFF]*(?:you said|you wrote|user message|your prompt|you asked)[:\s]*/i;
 const VISUALLY_HIDDEN_CLASS_FRAGMENT = 'visually-hidden';
 const INJECTED_UI_SELECTOR = '.gv-fork-btn, .gv-fork-confirm, .gv-fork-indicator-group';

--- a/src/pages/content/timeline/manager.ts
+++ b/src/pages/content/timeline/manager.ts
@@ -38,7 +38,10 @@ import type { StarredMessage, StarredMessagesData } from './starredTypes';
 import type { DotElement, MarkerLevel } from './types';
 
 /** Accessibility prefixes injected by Gemini's DOM that should be stripped from previews effectively globally. */
+// Anchored to the start, so it only strips leading invisible characters and can
+// never split an emoji sequence in the label body.
 const TURN_LABEL_PREFIXES =
+  // oxlint-disable-next-line no-misleading-character-class
   /^[\u200B\u200C\u200D\u200E\u200F\uFEFF]*(?:you said|you wrote|user message|your prompt|you asked)[:\s]*/i;
 const VISUALLY_HIDDEN_CLASS_FRAGMENT = 'visually-hidden';
 const INJECTED_UI_SELECTOR = '.gv-fork-btn, .gv-fork-confirm, .gv-fork-indicator-group';

--- a/src/pages/content/timestamp/__tests__/conversationHistoryObserver.test.ts
+++ b/src/pages/content/timestamp/__tests__/conversationHistoryObserver.test.ts
@@ -38,6 +38,7 @@ function installObserver(limits?: {
       `var MAX_BUFFER_BYTES = ${limits.bufferBytes};`,
     );
   }
+  // oxlint-disable-next-line no-eval -- evaluating the observer under test is what this suite exercises
   (0, eval)(source);
 }
 

--- a/src/pages/content/usageStatus/__tests__/usageObserver.test.ts
+++ b/src/pages/content/usageStatus/__tests__/usageObserver.test.ts
@@ -12,6 +12,7 @@ type UsageWindow = Window &
   };
 
 function installObserver(): void {
+  // oxlint-disable-next-line no-eval -- evaluating the observer under test is what this suite exercises
   (0, eval)(observerScript);
 }
 

--- a/src/pages/content/utils/routeWatcher.ts
+++ b/src/pages/content/utils/routeWatcher.ts
@@ -25,6 +25,7 @@ function checkRoute(event?: Event): void {
 
   const previousHref = lastHref;
   lastHref = currentHref;
+  // oxlint-disable-next-line unicorn/no-useless-spread -- snapshot: a listener may unsubscribe from inside its own callback
   for (const listener of [...listeners]) {
     try {
       listener({

--- a/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
@@ -10,6 +10,7 @@ const GEMINI_DOWNLOAD_URL_NO_DL = 'https://lh3.googleusercontent.com/rd-gg/examp
 const GEMINI_DOWNLOAD_URL_NO_RD = 'https://lh3.googleusercontent.com/gg-dl/example=d-I?alr=yes';
 
 function installInterceptor(): void {
+  // oxlint-disable-next-line no-eval -- evaluating the observer under test is what this suite exercises
   (0, eval)(interceptorScript);
 }
 


### PR DESCRIPTION
## Summary

Clears the 54 `correctness` findings the oxc migration (#949) surfaced, then turns the category into a build failure. The old ESLint config extended no recommended set — it hand-picked six rules plus jsx-a11y — so every base JS correctness rule had been off. Nothing regressed; this had simply never been checked.

Of the 54: **11 were real** (one user-visible bug, 10 pieces of dead code), **43 were false positives**, and one of those false positives would have introduced four fresh bugs if anyone had run `--fix-suggestions` on it.

| Commit | |
|---|---|
| `fix(mermaid)` | Composed emoji were being split in diagram labels |
| `refactor` | Delete 10 pieces of dead code, ~115 lines |
| `chore(lint)` | Annotate the 17 deliberate patterns with the reason |
| `build(lint)` | `categories: { correctness: "error" }` + 3 documented opt-outs |

## The real bug

`normalizeWhitespace` strips zero-width characters so stray invisibles from model output cannot break the Mermaid parser, and **U+200D sat in that class** next to U+200B and U+200C. U+200D is the zero-width *joiner*:

```
👨‍👩‍👦  →  👨👩👦      (5 code points → 3)
🏳️‍🌈   →  🏳️🌈
```

Any diagram label carrying a composed emoji lost it. Deleting U+200D from the class would have undone the case the strip was added for — a stray joiner between two identifiers (`graph<ZWJ>TD`) genuinely does break Mermaid, and there is a test pinning it. So the joiner is kept only when it actually joins, checking the code points on either side and skipping the variation selectors and skin-tone modifiers that sit between an emoji and its joiner. The walk uses `Array.from` rather than UTF-16 indices, so astral emoji are not split while deciding whether to split them. Recorded in the regression notes.

## The dead code

`no-unreachable` had never run. It found a `hashchange` dispatch sitting after `return true` in `prompt/index.ts` — harmless in the end, because all three listeners for it also listen for `popstate`, which the same function does dispatch, but it had never executed.

Removing the one unused function in `export/index.ts` exposed the next, and so on five deep: `extractTitleFromNativeSidebarByConversationId` → `extractTitleFromConversationElement` → `isMeaningfulConversationTitle` → `extractTitleFromLinkText` → `isGemLabel`. Live copies of every one of them exist in `PDFPrintService` and in the Gemini export adapter; this was a third, orphaned set — 107 lines. Plus two unused bindings, three more in `scripts/*.cjs` (newly linted), a single-element `Promise.all`, and a redundant `length === 0 ||` in front of an `every()`.

## The false positive that would have caused four bugs

`unicorn/no-useless-spread` flagged four `for (const x of [...collection])` loops. In every one, the loop body mutates that same collection — `unmount()` deletes from `this.active`, the code-block loops delete from `observedBlocks`/`managedBlocks`, and a route listener can unsubscribe from inside its own callback. The copy is what makes the iteration safe. Each now carries a `-- snapshot:` comment so the next reader does not "simplify" it.

The other annotated cases: control-character regexes that exist to match control characters, `offsetHeight` read to flush layout, three prefix patterns anchored with `^` that can never reach an emoji, two design-system primitives whose `htmlFor`/children come from the consumer, and test-only `eval`/optional-chaining.

## The three opt-outs

Every hit was a false positive, and the reasoning sits in the config next to the setting:

- **`jsx-a11y/prefer-tag-over-role`** — all 11 sites use the correct ARIA role where the suggested element is not a drop-in. `role="dialog"` on popovers that never call `showModal()`; `role="progressbar"` on a Tailwind-styled div with full `aria-valuemin/max/now`; `role="button"` on a card that **contains its own `<button>`**, so it cannot become one without nesting a button inside a button.
- **`react/set-state-in-effect`** — fires on every load-on-mount effect. Extension storage reads are async, so neither alternative the rule offers can express them.
- **`unicorn/no-new-array`** — `new Array(n).fill(x)` is the preallocation idiom in the timeline layout hot paths.

## Test

One assertion, for the invariant CI cannot see: `no-unreachable` is named nowhere in `rules`, so its severity comes entirely from `categories`. Drop that key and every correctness rule quietly falls back to a warning while the lint job keeps exiting 0. Mutation-verified — removing `categories` fails the suite.

Two more pin the emoji-joiner behaviour, alongside the original stray-joiner test.

## Verification

`format:check` (1214 files) · `lint` **0 errors, exit 0** · `typecheck` · **308 files / 3110 tests** · `i18n:check` · `regressions:check` (59 entries) · `build:chrome`.

Warnings drop 261 → 206, and the 206 remaining are all `no-console`, most of them in the `scripts/*.cjs` CLI helpers that oxlint newly covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLgncMki9zHG3Wo656Qyd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI lint policy changes can block merges on new correctness findings; the Mermaid whitespace change affects diagram label rendering, though export title behavior should be unchanged because dead code was removed.
> 
> **Overview**
> Turns on **`categories: { correctness: "error" }`** in oxlint so correctness issues fail CI, promotes **`no-unused-vars`** to error (so warnings don’t hide dead code), documents three deliberate rule opt-outs, and allows **`no-console`** in `scripts/**`. **`scripts/oxc-toolchain.test.js`** now asserts that category-only rules (e.g. `no-unreachable`) and unused bindings fail the lint run with a non-zero exit.
> 
> **User-visible fix:** Mermaid **`normalizeWhitespace`** no longer strips every U+200D zero-width joiner—it keeps joiners between emoji (family/flag sequences) while still removing stray joiners that break parsing, with new tests and regression notes.
> 
> **Cleanup from newly enforced rules:** Removes ~100 lines of orphaned conversation-title helpers from **`export/index.ts`** (live paths use the export adapter), deletes unreachable code after `return` in prompt navigation, drops redundant tag-filter logic, and trims unused script bindings. Adds targeted **`oxlint-disable`** comments where rules misfire (snapshot spreads, `eval` in observer tests, control-char regexes, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238d48d1f2c91cc6ecede9d9bd73e4503388625e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mermaid diagrams now preserve joined emoji sequences, such as family emojis, while removing stray invisible characters.
  - Improved saved-library navigation and simplified prompt tag filtering behavior.

- **Tests**
  - Added coverage for emoji joiners, variation selectors, and invalid standalone joiners.

- **Chores**
  - Strengthened linting checks and clarified intentional exceptions.
  - Removed unused code and streamlined internal processing without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->