### PR TITLE
feat(plugins): add DeepSeek site adapter

### DIFF
--- a/src/features/plugins/sites/adapters/deepseek.test.ts
+++ b/src/features/plugins/sites/adapters/deepseek.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deepseekAdapter } from './deepseek';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('class');
+});
+
+describe('DeepSeek content markers', () => {
+  it('distinguishes user, thinking-only, final and empty virtual turns', () => {
+    document.body.innerHTML =
+      '<div class="ds-message" id="user"><div class="ds-collapsible-text">Example</div></div>' +
+      '<div class="ds-message" id="thinking"><div class="ds-think-content">Working</div></div>' +
+      '<div class="ds-message" id="answer"><div class="ds-assistant-message-main-content">Answer</div></div>' +
+      '<div class="ds-message" id="pending"></div>' +
+      '<div class="ds-collapsible-text">Unrelated preview</div>';
+    const ids = (selector: string) =>
+      Array.from(document.querySelectorAll(selector), (el) => el.id);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    document
+      .querySelector('#thinking')
+      ?.insertAdjacentHTML(
+        'beforeend',
+        '<div class="ds-assistant-message-main-content">Finished</div>',
+      );
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+  });
+
+  it('finds the composer without matching unrelated editors', () => {
+    document.body.innerHTML =
+      '<textarea placeholder="Search"></textarea>' +
+      '<textarea class="ds-scroll-area" placeholder="Message DeepSeek" id="composer"></textarea>' +
+      '<div contenteditable="true"></div>';
+    expect(document.querySelectorAll(deepseekAdapter.selectors.composer)).toHaveLength(1);
+    expect(document.querySelector(deepseekAdapter.selectors.composer)?.id).toBe('composer');
+  });
+
+  it.each(['light', 'dark'])('recognizes the body %s theme', (theme) => {
+    document.body.className = 'zh_CN ' + theme;
+    expect(document.querySelector(deepseekAdapter.theme.hostSelector)).toBe(document.body);
+    expect(document.querySelector(deepseekAdapter.theme.lightSelector) !== null).toBe(
+      theme === 'light',
+    );
+    expect(document.querySelector(deepseekAdapter.theme.darkSelector) !== null).toBe(
+      theme === 'dark',
+    );
+  });
+});

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -4,18 +4,18 @@ import type { SiteAdapter, SiteCapability } from '../../types';
  * DeepSeek web app adapter (chat.deepseek.com).
  *
  * DeepSeek renders both user and assistant turns as ds-message elements.
- * Assistant turns expose ds-assistant-message-main-content; using that
- * stable semantic marker keeps the user selector independent of hashed classes.
+ * Match positive content markers: an unfinished assistant turn must never
+ * become a user turn simply because its final answer has not mounted yet.
  */
 export const deepseekAdapter: SiteAdapter = {
   id: 'deepseek',
   label: 'DeepSeek',
   matches: ['https://chat.deepseek.com/*'],
   selectors: {
-    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
-    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
-    sidebar: 'nav, aside',
+    userTurn:
+      '.ds-message:has(.ds-collapsible-text):not(:has(.ds-assistant-message-main-content, .ds-think-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content, .ds-think-content)',
+    composer: 'textarea.ds-scroll-area[placeholder*="DeepSeek" i]',
   },
   theme: {
     hostSelector: 'body',
@@ -23,5 +23,5 @@ export const deepseekAdapter: SiteAdapter = {
     darkSelector: 'body.dark',
   },
   brandColor: '#4d6bfe',
-  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+  capabilities: new Set<SiteCapability>(['chat', 'composer', 'darkMode']),
 };

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -1,0 +1,27 @@
+import type { SiteAdapter, SiteCapability } from '../../types';
+
+/**
+ * DeepSeek web app adapter (chat.deepseek.com).
+ *
+ * DeepSeek renders both user and assistant turns as ds-message elements.
+ * Assistant turns expose ds-assistant-message-main-content; using that
+ * stable semantic marker keeps the user selector independent of hashed classes.
+ */
+export const deepseekAdapter: SiteAdapter = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+  matches: ['https://chat.deepseek.com/*'],
+  selectors: {
+    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
+    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
+    sidebar: 'nav, aside',
+  },
+  theme: {
+    hostSelector: 'body',
+    lightSelector: 'body.light',
+    darkSelector: 'body.dark',
+  },
+  brandColor: '#4d6bfe',
+  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+};

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -49,21 +48,17 @@ describe('resolvePluginPlatformId', () => {
   });
 });
 
-describe('deepseekAdapter', () => {
-  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
-    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
-    expect(deepseekAdapter.selectors.userTurn).toBe(
-      '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    );
-    expect(deepseekAdapter.selectors.assistantTurn).toBe(
-      '.ds-message:has(.ds-assistant-message-main-content)',
-    );
-    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
-    expect(deepseekAdapter.theme).toEqual({
-      hostSelector: 'body',
-      lightSelector: 'body.light',
-      darkSelector: 'body.dark',
-    });
-    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
+describe('DeepSeek URL boundaries', () => {
+  it.each(['https://chat.deepseek.com/', 'https://chat.deepseek.com/a/chat/s/example?x=1#last'])(
+    'resolves %s as a plugin-only platform',
+    (url) => expect(resolvePluginPlatformId(url)).toBe('deepseek'),
+  );
+  it.each([
+    'https://deepseek.com/',
+    'https://api.deepseek.com/',
+    'https://chat.deepseek.com.example.org/',
+    'http://chat.deepseek.com/',
+  ])('does not grant platform support to %s', (url) => {
+    expect(SiteRegistry.createDefault().resolveByUrl(url)).toBeNull();
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -45,5 +46,24 @@ describe('resolvePluginPlatformId', () => {
   it('returns null for sites Voyager ships no adapter for', () => {
     expect(resolvePluginPlatformId('https://example.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://deepseek.com/')).toBeNull();
+  });
+});
+
+describe('deepseekAdapter', () => {
+  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
+    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
+    expect(deepseekAdapter.selectors.userTurn).toBe(
+      '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    );
+    expect(deepseekAdapter.selectors.assistantTurn).toBe(
+      '.ds-message:has(.ds-assistant-message-main-content)',
+    );
+    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
+    expect(deepseekAdapter.theme).toEqual({
+      hostSelector: 'body',
+      lightSelector: 'body.light',
+      darkSelector: 'body.dark',
+    });
+    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -14,6 +14,7 @@ describe('SiteRegistry.resolveByUrl', () => {
     expect(
       registry.resolveByUrl('https://artifact-id.frame.claudeusercontent.com/_f/version/')?.id,
     ).toBe('claude');
+    expect(registry.resolveByUrl('https://chat.deepseek.com/a/chat/s/abc')?.id).toBe('deepseek');
   });
 
   it('returns null for sites with no adapter', () => {
@@ -30,6 +31,7 @@ describe('resolvePluginPlatformId', () => {
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
     expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
+    expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 
   it('returns null for native Voyager sites (full feature set runs there)', () => {

--- a/src/features/plugins/sites/registry.ts
+++ b/src/features/plugins/sites/registry.ts
@@ -9,6 +9,7 @@ import type { SiteAdapter, SiteId } from '../types';
 import { aistudioAdapter } from './adapters/aistudio';
 import { chatgptAdapter } from './adapters/chatgpt';
 import { claudeAdapter } from './adapters/claude';
+import { deepseekAdapter } from './adapters/deepseek';
 import { geminiAdapter } from './adapters/gemini';
 import { grokAdapter } from './adapters/grok';
 import { matchesAnyPattern } from './matchPattern';
@@ -19,6 +20,7 @@ export const DEFAULT_ADAPTERS: readonly SiteAdapter[] = [
   chatgptAdapter,
   claudeAdapter,
   grokAdapter,
+  deepseekAdapter,
 ];
 
 /**

--- a/src/features/plugins/types.ts
+++ b/src/features/plugins/types.ts
@@ -19,7 +19,14 @@
 // Sites
 // ---------------------------------------------------------------------------
 
-export const KNOWN_SITE_IDS = ['gemini', 'aistudio', 'chatgpt', 'claude', 'grok'] as const;
+export const KNOWN_SITE_IDS = [
+  'gemini',
+  'aistudio',
+  'chatgpt',
+  'claude',
+  'grok',
+  'deepseek',
+] as const;
 export type KnownSiteId = (typeof KNOWN_SITE_IDS)[number];
 
 /**


### PR DESCRIPTION
## Summary

Add the DeepSeek web app as a Voyager plugin platform through the existing SiteAdapter and SiteRegistry architecture.

This follows the maintainer direction to start with DeepSeek platform support. The target is the DeepSeek web app at chat.deepseek.com, not a DeepSeek API provider integration and not a copy of Voyager Gemini-native features.

## What changed

- Register deepseek as a known plugin-platform site.
- Add a deepseekAdapter for https://chat.deepseek.com/*.
- Match user turns through the visible collapsible user content marker.
- Match thinking and final assistant turns through positive DeepSeek content markers.
- Match the DeepSeek composer through its textarea class and placeholder.
- Detect the observed body.light and body.dark theme markers.
- Keep the adapter conservative: no sidebar capability is advertised because the tested page did not expose a reliable sidebar semantic element.
- Add URL, registration, selector, message-state and theme regression tests.

## Maintainer direction

This is the first layer of a planned stacked contribution. The maintainer recommended starting with a new platform adapter and then adding independent DeepSeek plugin capabilities. The next layer, DeepSeek reading width, is prepared on the dependent branch codex/deepseek-reading-width but is intentionally not included in this PR.

## Verification

- bun run typecheck passed.
- bun run format:check passed.
- bun run lint:check passed with existing repository warnings only.
- bun run test -- src/features/plugins --maxWorkers=1 --silent passed: 26 files, 295 tests.
- bun run build:chrome passed.
- bun run build:firefox passed.
- bun run build:safari passed, including Safari resource wiring.
- Full sequential suite: 3433 passed, 2 existing Windows release-privacy tests failed (EPERM symlink creation and embedded.provisionprofile filename handling). The same failures reproduce against the unmodified upstream baseline; unrelated code was not changed.

## Live investigation and pending browser checks

The real DeepSeek page was inspected in the Codex in-app browser without sending messages or uploading account data. The observed DOM confirmed .ds-message, .ds-collapsible-text, .ds-think-content, .ds-assistant-message-main-content, textarea.ds-scroll-area, and body.light.

The extension artifact has not yet been loaded in Chrome, Firefox or Safari. Pending checks are optional host permission, popup enable/disable/re-enable, extension reload, streamed responses, light/dark theme switching, and cleanup after disabling. The current Codex in-app browser does not expose local extension installation, so those checks remain explicitly pending.

## Scope

No manifest host permissions, API clients, Gemini core features, remote JavaScript, storage migrations, or unrelated refactors were added.
