### PR TITLE
feat(plugins): add DeepSeek platform adapter

### DIFF
--- a/src/features/plugins/sites/adapters/deepseek.test.ts
+++ b/src/features/plugins/sites/adapters/deepseek.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deepseekAdapter } from './deepseek';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('class');
+});
+
+describe('DeepSeek content markers', () => {
+  it('distinguishes user, thinking-only, final and empty virtual turns', () => {
+    document.body.innerHTML =
+      '<div class="ds-message" id="user"><div class="ds-collapsible-text">Example</div></div>' +
+      '<div class="ds-message" id="thinking"><div class="ds-think-content">Working</div></div>' +
+      '<div class="ds-message" id="answer"><div class="ds-assistant-message-main-content">Answer</div></div>' +
+      '<div class="ds-message" id="pending"></div>' +
+      '<div class="ds-collapsible-text">Unrelated preview</div>';
+    const ids = (selector: string) =>
+      Array.from(document.querySelectorAll(selector), (el) => el.id);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    document
+      .querySelector('#thinking')
+      ?.insertAdjacentHTML(
+        'beforeend',
+        '<div class="ds-assistant-message-main-content">Finished</div>',
+      );
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+  });
+
+  it('finds the composer without matching unrelated editors', () => {
+    document.body.innerHTML =
+      '<textarea placeholder="Search"></textarea>' +
+      '<textarea class="ds-scroll-area" placeholder="Message DeepSeek" id="composer"></textarea>' +
+      '<div contenteditable="true"></div>';
+    expect(document.querySelectorAll(deepseekAdapter.selectors.composer)).toHaveLength(1);
+    expect(document.querySelector(deepseekAdapter.selectors.composer)?.id).toBe('composer');
+  });
+
+  it.each(['light', 'dark'])('recognizes the body %s theme', (theme) => {
+    document.body.className = 'zh_CN ' + theme;
+    expect(document.querySelector(deepseekAdapter.theme.hostSelector)).toBe(document.body);
+    expect(document.querySelector(deepseekAdapter.theme.lightSelector) !== null).toBe(
+      theme === 'light',
+    );
+    expect(document.querySelector(deepseekAdapter.theme.darkSelector) !== null).toBe(
+      theme === 'dark',
+    );
+  });
+});

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -4,18 +4,18 @@ import type { SiteAdapter, SiteCapability } from '../../types';
  * DeepSeek web app adapter (chat.deepseek.com).
  *
  * DeepSeek renders both user and assistant turns as ds-message elements.
- * Assistant turns expose ds-assistant-message-main-content; using that
- * stable semantic marker keeps the user selector independent of hashed classes.
+ * Match positive content markers: an unfinished assistant turn must never
+ * become a user turn simply because its final answer has not mounted yet.
  */
 export const deepseekAdapter: SiteAdapter = {
   id: 'deepseek',
   label: 'DeepSeek',
   matches: ['https://chat.deepseek.com/*'],
   selectors: {
-    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
-    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
-    sidebar: 'nav, aside',
+    userTurn:
+      '.ds-message:has(.ds-collapsible-text):not(:has(.ds-assistant-message-main-content, .ds-think-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content, .ds-think-content)',
+    composer: 'textarea.ds-scroll-area[placeholder*="DeepSeek" i]',
   },
   theme: {
     hostSelector: 'body',
@@ -23,5 +23,5 @@ export const deepseekAdapter: SiteAdapter = {
     darkSelector: 'body.dark',
   },
   brandColor: '#4d6bfe',
-  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+  capabilities: new Set<SiteCapability>(['chat', 'composer', 'darkMode']),
 };

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -1,0 +1,27 @@
+import type { SiteAdapter, SiteCapability } from '../../types';
+
+/**
+ * DeepSeek web app adapter (chat.deepseek.com).
+ *
+ * DeepSeek renders both user and assistant turns as ds-message elements.
+ * Assistant turns expose ds-assistant-message-main-content; using that
+ * stable semantic marker keeps the user selector independent of hashed classes.
+ */
+export const deepseekAdapter: SiteAdapter = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+  matches: ['https://chat.deepseek.com/*'],
+  selectors: {
+    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
+    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
+    sidebar: 'nav, aside',
+  },
+  theme: {
+    hostSelector: 'body',
+    lightSelector: 'body.light',
+    darkSelector: 'body.dark',
+  },
+  brandColor: '#4d6bfe',
+  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+};

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -49,21 +48,17 @@ describe('resolvePluginPlatformId', () => {
   });
 });
 
-describe('deepseekAdapter', () => {
-  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
-    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
-    expect(deepseekAdapter.selectors.userTurn).toBe(
-      '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    );
-    expect(deepseekAdapter.selectors.assistantTurn).toBe(
-      '.ds-message:has(.ds-assistant-message-main-content)',
-    );
-    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
-    expect(deepseekAdapter.theme).toEqual({
-      hostSelector: 'body',
-      lightSelector: 'body.light',
-      darkSelector: 'body.dark',
-    });
-    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
+describe('DeepSeek URL boundaries', () => {
+  it.each(['https://chat.deepseek.com/', 'https://chat.deepseek.com/a/chat/s/example?x=1#last'])(
+    'resolves %s as a plugin-only platform',
+    (url) => expect(resolvePluginPlatformId(url)).toBe('deepseek'),
+  );
+  it.each([
+    'https://deepseek.com/',
+    'https://api.deepseek.com/',
+    'https://chat.deepseek.com.example.org/',
+    'http://chat.deepseek.com/',
+  ])('does not grant platform support to %s', (url) => {
+    expect(SiteRegistry.createDefault().resolveByUrl(url)).toBeNull();
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -45,5 +46,24 @@ describe('resolvePluginPlatformId', () => {
   it('returns null for sites Voyager ships no adapter for', () => {
     expect(resolvePluginPlatformId('https://example.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://deepseek.com/')).toBeNull();
+  });
+});
+
+describe('deepseekAdapter', () => {
+  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
+    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
+    expect(deepseekAdapter.selectors.userTurn).toBe(
+      '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    );
+    expect(deepseekAdapter.selectors.assistantTurn).toBe(
+      '.ds-message:has(.ds-assistant-message-main-content)',
+    );
+    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
+    expect(deepseekAdapter.theme).toEqual({
+      hostSelector: 'body',
+      lightSelector: 'body.light',
+      darkSelector: 'body.dark',
+    });
+    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -14,6 +14,7 @@ describe('SiteRegistry.resolveByUrl', () => {
     expect(
       registry.resolveByUrl('https://artifact-id.frame.claudeusercontent.com/_f/version/')?.id,
     ).toBe('claude');
+    expect(registry.resolveByUrl('https://chat.deepseek.com/a/chat/s/abc')?.id).toBe('deepseek');
   });
 
   it('returns null for sites with no adapter', () => {
@@ -30,6 +31,7 @@ describe('resolvePluginPlatformId', () => {
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
     expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
+    expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 
   it('returns null for native Voyager sites (full feature set runs there)', () => {

--- a/src/features/plugins/sites/registry.ts
+++ b/src/features/plugins/sites/registry.ts
@@ -9,6 +9,7 @@ import type { SiteAdapter, SiteId } from '../types';
 import { aistudioAdapter } from './adapters/aistudio';
 import { chatgptAdapter } from './adapters/chatgpt';
 import { claudeAdapter } from './adapters/claude';
+import { deepseekAdapter } from './adapters/deepseek';
 import { geminiAdapter } from './adapters/gemini';
 import { grokAdapter } from './adapters/grok';
 import { matchesAnyPattern } from './matchPattern';
@@ -19,6 +20,7 @@ export const DEFAULT_ADAPTERS: readonly SiteAdapter[] = [
   chatgptAdapter,
   claudeAdapter,
   grokAdapter,
+  deepseekAdapter,
 ];
 
 /**

--- a/src/features/plugins/types.ts
+++ b/src/features/plugins/types.ts
@@ -19,7 +19,14 @@
 // Sites
 // ---------------------------------------------------------------------------
 
-export const KNOWN_SITE_IDS = ['gemini', 'aistudio', 'chatgpt', 'claude', 'grok'] as const;
+export const KNOWN_SITE_IDS = [
+  'gemini',
+  'aistudio',
+  'chatgpt',
+  'claude',
+  'grok',
+  'deepseek',
+] as const;
 export type KnownSiteId = (typeof KNOWN_SITE_IDS)[number];
 
 /**


### PR DESCRIPTION
## Related issue
Closes #960

## Scope
Register chat.deepseek.com as a plugin-only platform using the existing SiteAdapter and SiteRegistry. Add conservative user/thinking/assistant/composer selectors and body theme descriptors with DOM behavior and URL-boundary tests. No static host grants, remote code, API clients or Gemini feature duplication.

## Resubmission
Replacement for closed #959, which should remain closed. The contributor reports renewed direct permission from @Nagi-ovo to submit focused DeepSeek PRs. Public issue #960 now precedes this resubmission. Please apply the repository's maintainer intake approval if required; this remains a feature, not a bug-fix retitle.

## Test evidence
PR head: a0b2d72a325f524671c062d7501e1484561adcbd.
At this exact head, reran: bun run test -- src/features/plugins/sites --maxWorkers=1 --silent (3 files / 22 tests passed).
Earlier checks on the combined descendant bd4b997924a68ac7c6eed5b1d0490abffdb9c86d: typecheck, format, lint, plugin suite (295 tests), Chrome/Firefox/Safari builds passed. Full sequential suite on that combined tree: 3433 passed / 2 failed. These aggregate results are NOT claimed as a fresh full run on this PR head. The two release-privacy failures also reproduced on the original main baseline on Windows.

## Browser evidence and gaps
Real DeepSeek DOM inspected without sending messages. Light body marker observed; dark marker covered by fixture only. Full extension loading, optional host permission, toggles, reload, streamed conversations and browser-matrix checks remain pending. Owner for collecting first manual evidence: @ccch1mneyyy; other-browser assistance has not yet been assigned. Full verify:pr has not passed, and no public visual evidence is attached. Keep draft until required checks are complete.

## Separate contribution
Reading-width feature is tracked separately in #961 and has no production dependency on this adapter; an empty-registry PluginHost test verifies that distinction. Each PR can therefore be reviewed against main with a focused diff.
