### PR TITLE
feat(plugins): add DeepSeek platform adapter

### DIFF
--- a/src/features/plugins/sites/adapters/deepseek.test.ts
+++ b/src/features/plugins/sites/adapters/deepseek.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deepseekAdapter } from './deepseek';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('class');
+});
+
+describe('DeepSeek content markers', () => {
+  it('distinguishes user, thinking-only, final and empty virtual turns', () => {
+    document.body.innerHTML =
+      '<div class="ds-message" id="user"><div class="ds-collapsible-text">Example</div></div>' +
+      '<div class="ds-message" id="thinking"><div class="ds-think-content">Working</div></div>' +
+      '<div class="ds-message" id="answer"><div class="ds-assistant-message-main-content">Answer</div></div>' +
+      '<div class="ds-message" id="pending"></div>' +
+      '<div class="ds-collapsible-text">Unrelated preview</div>';
+    const ids = (selector: string) =>
+      Array.from(document.querySelectorAll(selector), (el) => el.id);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    document
+      .querySelector('#thinking')
+      ?.insertAdjacentHTML(
+        'beforeend',
+        '<div class="ds-assistant-message-main-content">Finished</div>',
+      );
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+  });
+
+  it('finds the composer without matching unrelated editors', () => {
+    document.body.innerHTML =
+      '<textarea placeholder="Search"></textarea>' +
+      '<textarea class="ds-scroll-area" placeholder="Message DeepSeek" id="composer"></textarea>' +
+      '<div contenteditable="true"></div>';
+    expect(document.querySelectorAll(deepseekAdapter.selectors.composer)).toHaveLength(1);
+    expect(document.querySelector(deepseekAdapter.selectors.composer)?.id).toBe('composer');
+  });
+
+  it.each(['light', 'dark'])('recognizes the body %s theme', (theme) => {
+    document.body.className = 'zh_CN ' + theme;
+    expect(document.querySelector(deepseekAdapter.theme.hostSelector)).toBe(document.body);
+    expect(document.querySelector(deepseekAdapter.theme.lightSelector) !== null).toBe(
+      theme === 'light',
+    );
+    expect(document.querySelector(deepseekAdapter.theme.darkSelector) !== null).toBe(
+      theme === 'dark',
+    );
+  });
+});

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -4,18 +4,18 @@ import type { SiteAdapter, SiteCapability } from '../../types';
  * DeepSeek web app adapter (chat.deepseek.com).
  *
  * DeepSeek renders both user and assistant turns as ds-message elements.
- * Assistant turns expose ds-assistant-message-main-content; using that
- * stable semantic marker keeps the user selector independent of hashed classes.
+ * Match positive content markers: an unfinished assistant turn must never
+ * become a user turn simply because its final answer has not mounted yet.
  */
 export const deepseekAdapter: SiteAdapter = {
   id: 'deepseek',
   label: 'DeepSeek',
   matches: ['https://chat.deepseek.com/*'],
   selectors: {
-    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
-    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
-    sidebar: 'nav, aside',
+    userTurn:
+      '.ds-message:has(.ds-collapsible-text):not(:has(.ds-assistant-message-main-content, .ds-think-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content, .ds-think-content)',
+    composer: 'textarea.ds-scroll-area[placeholder*="DeepSeek" i]',
   },
   theme: {
     hostSelector: 'body',
@@ -23,5 +23,5 @@ export const deepseekAdapter: SiteAdapter = {
     darkSelector: 'body.dark',
   },
   brandColor: '#4d6bfe',
-  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+  capabilities: new Set<SiteCapability>(['chat', 'composer', 'darkMode']),
 };

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -1,0 +1,27 @@
+import type { SiteAdapter, SiteCapability } from '../../types';
+
+/**
+ * DeepSeek web app adapter (chat.deepseek.com).
+ *
+ * DeepSeek renders both user and assistant turns as ds-message elements.
+ * Assistant turns expose ds-assistant-message-main-content; using that
+ * stable semantic marker keeps the user selector independent of hashed classes.
+ */
+export const deepseekAdapter: SiteAdapter = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+  matches: ['https://chat.deepseek.com/*'],
+  selectors: {
+    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
+    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
+    sidebar: 'nav, aside',
+  },
+  theme: {
+    hostSelector: 'body',
+    lightSelector: 'body.light',
+    darkSelector: 'body.dark',
+  },
+  brandColor: '#4d6bfe',
+  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+};

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -14,6 +14,7 @@ describe('SiteRegistry.resolveByUrl', () => {
     expect(
       registry.resolveByUrl('https://artifact-id.frame.claudeusercontent.com/_f/version/')?.id,
     ).toBe('claude');
+    expect(registry.resolveByUrl('https://chat.deepseek.com/a/chat/s/abc')?.id).toBe('deepseek');
   });
 
   it('returns null for sites with no adapter', () => {
@@ -29,6 +30,8 @@ describe('resolvePluginPlatformId', () => {
     expect(
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
+    expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
+    expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 
   it('returns null for native Voyager sites (full feature set runs there)', () => {

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -50,21 +49,17 @@ describe('resolvePluginPlatformId', () => {
   });
 });
 
-describe('deepseekAdapter', () => {
-  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
-    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
-    expect(deepseekAdapter.selectors.userTurn).toBe(
-      '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    );
-    expect(deepseekAdapter.selectors.assistantTurn).toBe(
-      '.ds-message:has(.ds-assistant-message-main-content)',
-    );
-    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
-    expect(deepseekAdapter.theme).toEqual({
-      hostSelector: 'body',
-      lightSelector: 'body.light',
-      darkSelector: 'body.dark',
-    });
-    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
+describe('DeepSeek URL boundaries', () => {
+  it.each(['https://chat.deepseek.com/', 'https://chat.deepseek.com/a/chat/s/example?x=1#last'])(
+    'resolves %s as a plugin-only platform',
+    (url) => expect(resolvePluginPlatformId(url)).toBe('deepseek'),
+  );
+  it.each([
+    'https://deepseek.com/',
+    'https://api.deepseek.com/',
+    'https://chat.deepseek.com.example.org/',
+    'http://chat.deepseek.com/',
+  ])('does not grant platform support to %s', (url) => {
+    expect(SiteRegistry.createDefault().resolveByUrl(url)).toBeNull();
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -30,7 +30,6 @@ describe('resolvePluginPlatformId', () => {
     expect(
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
-    expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
     expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -46,5 +47,24 @@ describe('resolvePluginPlatformId', () => {
     expect(resolvePluginPlatformId('https://example.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://deepseek.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://grok.com/')).toBeNull();
+  });
+});
+
+describe('deepseekAdapter', () => {
+  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
+    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
+    expect(deepseekAdapter.selectors.userTurn).toBe(
+      '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    );
+    expect(deepseekAdapter.selectors.assistantTurn).toBe(
+      '.ds-message:has(.ds-assistant-message-main-content)',
+    );
+    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
+    expect(deepseekAdapter.theme).toEqual({
+      hostSelector: 'body',
+      lightSelector: 'body.light',
+      darkSelector: 'body.dark',
+    });
+    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
   });
 });

--- a/src/features/plugins/sites/registry.ts
+++ b/src/features/plugins/sites/registry.ts
@@ -9,6 +9,7 @@ import type { SiteAdapter, SiteId } from '../types';
 import { aistudioAdapter } from './adapters/aistudio';
 import { chatgptAdapter } from './adapters/chatgpt';
 import { claudeAdapter } from './adapters/claude';
+import { deepseekAdapter } from './adapters/deepseek';
 import { geminiAdapter } from './adapters/gemini';
 import { matchesAnyPattern } from './matchPattern';
 
@@ -17,12 +18,13 @@ export const DEFAULT_ADAPTERS: readonly SiteAdapter[] = [
   aistudioAdapter,
   chatgptAdapter,
   claudeAdapter,
+  deepseekAdapter,
 ];
 
 /**
  * Site ids Voyager treats as first-party "native" surfaces — these get the full
  * Gemini Voyager feature set (Timeline, Folders, Prompt Manager, …). Every other
- * adapter (Claude / ChatGPT) is a *plugin platform*: declarative plugins
+ * adapter (Claude / ChatGPT / DeepSeek) is a *plugin platform*: declarative plugins
  * + platform theming only, never core Gemini features.
  */
 export const NATIVE_SITE_IDS: ReadonlySet<SiteId> = new Set<SiteId>(['gemini', 'aistudio']);
@@ -54,7 +56,7 @@ export class SiteRegistry {
 }
 
 /**
- * Resolve the id of a third-party *plugin platform* for a URL (Claude / ChatGPT),
+ * Resolve the id of a third-party *plugin platform* for a URL (Claude / ChatGPT / DeepSeek),
  * or `null` when the URL is a native Voyager site (Gemini / AI Studio)
  * or has no adapter at all. The content script uses this to keep core Gemini
  * features off plugin-only platforms while still running the plugin host + theme.

--- a/src/features/plugins/types.ts
+++ b/src/features/plugins/types.ts
@@ -19,7 +19,13 @@
 // Sites
 // ---------------------------------------------------------------------------
 
-export const KNOWN_SITE_IDS = ['gemini', 'aistudio', 'chatgpt', 'claude'] as const;
+export const KNOWN_SITE_IDS = [
+  'gemini',
+  'aistudio',
+  'chatgpt',
+  'claude',
+  'deepseek',
+] as const;
 export type KnownSiteId = (typeof KNOWN_SITE_IDS)[number];
 
 /**


### PR DESCRIPTION
## Summary

Add the DeepSeek web app as a Voyager plugin platform through the existing `SiteAdapter` and `SiteRegistry` architecture.

Target: `https://chat.deepseek.com/*`

## Scope

- Register DeepSeek as a known plugin platform.
- Add conservative user, thinking, assistant, composer and theme selectors based on the observed DeepSeek DOM.
- Keep DeepSeek plugin-only; do not copy Gemini-native features.
- Add URL, registration, selector, message-state and theme regression tests.
- Do not add API provider integration, required host permissions, remote code or static manifest grants.

## Related issue

Closes #960

## Verification

DeepSeek and plugin tests, typecheck, formatting, lint and Chrome/Firefox/Safari builds were run during preparation. The real DeepSeek page was inspected read-only; no private conversation data or credentials were uploaded.

The final browser-extension load, optional permission prompt, enable/disable cycle, streamed response and public redacted screenshot remain pending for manual verification.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
