### PR TITLE
feat(plugins): add adjustable DeepSeek reading width

### DIFF
--- a/src/features/plugins/catalog/marketplace.json
+++ b/src/features/plugins/catalog/marketplace.json
@@ -22,6 +22,11 @@
       "name": "chatgpt-reading-width",
       "source": "plugins/chatgpt-reading-width/plugin.json",
       "official": true
+    },
+    {
+      "name": "deepseek-reading-width",
+      "source": "plugins/deepseek-reading-width/plugin.json",
+      "official": true
     }
   ]
 }

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/README.md
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/README.md
@@ -1,0 +1,23 @@
+---
+id: voyager.deepseek-reading-width
+name: DeepSeek · Comfortable Reading Width
+category: readability
+version: 1.0.0
+author: voyager-official
+license: MIT
+matches:
+  - https://chat.deepseek.com/*
+engine: '>=1.2.0'
+settings:
+  width: 'number (600-1600, default 712) - max reading width in pixels'
+---
+
+# DeepSeek - Comfortable Reading Width
+
+Gives DeepSeek one centered, adjustable reading column. The plugin follows
+DeepSeek's native --message-list-max-width variable and keeps the virtual
+message-list containers within the configured width.
+
+This is a declarative plugin: pure CSS and a typed setting interpreted by
+Voyager's bundled plugin engine. It does not execute remote JavaScript or load
+external resources.

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/README.md
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/README.md
@@ -14,9 +14,14 @@ settings:
 
 # DeepSeek - Comfortable Reading Width
 
-Gives DeepSeek one centered, adjustable reading column. The plugin follows
-DeepSeek's native --message-list-max-width variable and keeps the virtual
-message-list containers within the configured width.
+Gives DeepSeek one centered, adjustable reading column (600-1600 px, default
+712 px). The column shrinks to the available chat area with 20 px side gutters.
+It scopes horizontal sizing to the printable virtual list containing messages,
+replacing its native calculated horizontal padding while preserving vertical
+padding, transforms and virtualization. Other lists and the composer stay native.
+
+Disable the plugin to restore the native layout. Settings and enable state use
+Voyager's existing plugin storage and optional host-permission flow.
 
 This is a declarative plugin: pure CSS and a typed setting interpreted by
 Voyager's bundled plugin engine. It does not execute remote JavaScript or load

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/plugin.json
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/plugin.json
@@ -1,0 +1,109 @@
+{
+  "id": "voyager.deepseek-reading-width",
+  "name": "DeepSeek · Comfortable Reading Width",
+  "version": "1.0.0",
+  "description": "Widen DeepSeek's conversation to one centered, adjustable reading column.",
+  "i18n": {
+    "zh": {
+      "name": "DeepSeek · 舒适阅读宽度",
+      "description": "将 DeepSeek 对话拓宽为居中、可调节的阅读列。",
+      "settings": { "width": { "label": "阅读宽度（px）", "minLabel": "更窄", "maxLabel": "更宽" } }
+    },
+    "zh_TW": {
+      "name": "DeepSeek · 舒適閱讀寬度",
+      "description": "將 DeepSeek 對話拓寬為置中、可調整的閱讀欄。",
+      "settings": { "width": { "label": "閱讀寬度（px）", "minLabel": "更窄", "maxLabel": "更寬" } }
+    },
+    "ja": {
+      "name": "DeepSeek · 快適な読書幅",
+      "description": "DeepSeek の会話を中央寄せの調整可能な 1 カラムに広げます。",
+      "settings": { "width": { "label": "読書幅（px）", "minLabel": "狭く", "maxLabel": "広く" } }
+    },
+    "ko": {
+      "name": "DeepSeek · 편안한 읽기 너비",
+      "description": "DeepSeek 대화를 가운데 정렬된 조절 가능한 읽기 열로 넓힙니다.",
+      "settings": { "width": { "label": "읽기 너비(px)", "minLabel": "좁게", "maxLabel": "넓게" } }
+    },
+    "fr": {
+      "name": "DeepSeek · Largeur de lecture confortable",
+      "description": "Élargit la conversation DeepSeek dans une colonne de lecture centrée et réglable.",
+      "settings": {
+        "width": {
+          "label": "Largeur de lecture (px)",
+          "minLabel": "Plus étroit",
+          "maxLabel": "Plus large"
+        }
+      }
+    },
+    "es": {
+      "name": "DeepSeek · Ancho de lectura cómodo",
+      "description": "Amplía la conversación de DeepSeek en una columna de lectura centrada y ajustable.",
+      "settings": {
+        "width": {
+          "label": "Ancho de lectura (px)",
+          "minLabel": "Más estrecho",
+          "maxLabel": "Más ancho"
+        }
+      }
+    },
+    "pt": {
+      "name": "DeepSeek · Largura de leitura confortável",
+      "description": "Amplia a conversa do DeepSeek para uma coluna de leitura centralizada e ajustável.",
+      "settings": {
+        "width": {
+          "label": "Largura de leitura (px)",
+          "minLabel": "Mais estreito",
+          "maxLabel": "Mais largo"
+        }
+      }
+    },
+    "ru": {
+      "name": "DeepSeek · Удобная ширина чтения",
+      "description": "Расширяет диалог DeepSeek до центрированной настраиваемой колонки для чтения.",
+      "settings": {
+        "width": { "label": "Ширина чтения (px)", "minLabel": "Уже", "maxLabel": "Шире" }
+      }
+    },
+    "ar": {
+      "name": "DeepSeek · عرض قراءة مريح",
+      "description": "يوسّع محادثة DeepSeek إلى عمود قراءة مركزي قابل للتعديل.",
+      "settings": {
+        "width": { "label": "عرض القراءة (px)", "minLabel": "أضيق", "maxLabel": "أوسع" }
+      }
+    }
+  },
+  "author": "voyager-official",
+  "category": "readability",
+  "license": "MIT",
+  "homepage": "https://github.com/Nagi-ovo/voyager/tree/main/src/features/plugins/catalog/plugins/deepseek-reading-width",
+  "engine": ">=1.2.0",
+  "tier": "declarative",
+  "matches": ["https://chat.deepseek.com/*"],
+  "contributes": {
+    "settings": {
+      "width": {
+        "type": "number",
+        "label": "Reading width (px)",
+        "minLabel": "Narrower",
+        "maxLabel": "Wider",
+        "default": 712,
+        "min": 600,
+        "max": 1600
+      }
+    },
+    "styles": [{ "file": "style.css" }],
+    "domOps": [
+      { "op": "addClass", "target": "body", "className": "gv-plugin-deepseek-readable" },
+      {
+        "op": "setStyle",
+        "target": "body",
+        "styles": { "--gv-plugin-reading-width": "{{width}}px" }
+      },
+      {
+        "op": "setStyle",
+        "target": "body",
+        "styles": { "--message-list-max-width": "{{width}}px" }
+      }
+    ]
+  }
+}

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/plugin.json
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/plugin.json
@@ -98,11 +98,6 @@
         "op": "setStyle",
         "target": "body",
         "styles": { "--gv-plugin-reading-width": "{{width}}px" }
-      },
-      {
-        "op": "setStyle",
-        "target": "body",
-        "styles": { "--message-list-max-width": "{{width}}px" }
       }
     ]
   }

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/style.css
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/style.css
@@ -1,0 +1,17 @@
+/* voyager.deepseek-reading-width - one centered, adjustable reading column. */
+.gv-plugin-deepseek-readable {
+  --message-list-max-width: var(--gv-plugin-reading-width, 712px) !important;
+}
+
+.gv-plugin-deepseek-readable .ds-virtual-list-items,
+.gv-plugin-deepseek-readable .ds-virtual-list-visible-items,
+.gv-plugin-deepseek-readable .ds-message {
+  width: min(var(--gv-plugin-reading-width, 712px), calc(100vw - 40px)) !important;
+  max-width: var(--gv-plugin-reading-width, 712px) !important;
+}
+
+.gv-plugin-deepseek-readable .ds-virtual-list-visible-items,
+.gv-plugin-deepseek-readable .ds-message {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}

--- a/src/features/plugins/catalog/plugins/deepseek-reading-width/style.css
+++ b/src/features/plugins/catalog/plugins/deepseek-reading-width/style.css
@@ -1,17 +1,11 @@
-/* voyager.deepseek-reading-width - one centered, adjustable reading column. */
-.gv-plugin-deepseek-readable {
-  --message-list-max-width: var(--gv-plugin-reading-width, 712px) !important;
-}
-
-.gv-plugin-deepseek-readable .ds-virtual-list-items,
-.gv-plugin-deepseek-readable .ds-virtual-list-visible-items,
-.gv-plugin-deepseek-readable .ds-message {
-  width: min(var(--gv-plugin-reading-width, 712px), calc(100vw - 40px)) !important;
-  max-width: var(--gv-plugin-reading-width, 712px) !important;
-}
-
-.gv-plugin-deepseek-readable .ds-virtual-list-visible-items,
-.gv-plugin-deepseek-readable .ds-message {
+/* Keep native virtual-list transforms and vertical sizing intact.
+ * Only the chat list is widened; side lists and the composer stay native. */
+.gv-plugin-deepseek-readable .ds-virtual-list--printable > .ds-virtual-list-items:has(.ds-message) {
+  box-sizing: border-box !important;
+  width: min(var(--gv-plugin-reading-width, 712px), calc(100% - 40px)) !important;
+  max-width: calc(100% - 40px) !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
   margin-left: auto !important;
   margin-right: auto !important;
 }

--- a/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
+++ b/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
@@ -14,6 +14,7 @@ describe('BundledCatalogPluginSource', () => {
       'voyager.claude-cjk-render-fix',
       'voyager.claude-reading-width',
       'voyager.chatgpt-reading-width',
+      'voyager.deepseek-reading-width',
     ]);
 
     for (const manifest of manifests) {
@@ -31,6 +32,7 @@ describe('BundledCatalogPluginSource', () => {
       '../catalog/plugins/claude-cjk-render-fix/style.css',
       '../catalog/plugins/claude-reading-width/style.css',
       '../catalog/plugins/chatgpt-reading-width/style.css',
+      '../catalog/plugins/deepseek-reading-width/style.css',
     ]) {
       expect(readFileSync(new URL(file, import.meta.url), 'utf8').length).toBeGreaterThan(0);
     }
@@ -63,6 +65,34 @@ describe('BundledCatalogPluginSource', () => {
     expect(regularWidthRule).toBeGreaterThanOrEqual(0);
     expect(footerOverride).toBeGreaterThan(regularWidthRule);
     expect(centeredTurnRule).toBeGreaterThan(footerOverride);
+  });
+
+  it('supports DeepSeek reading width through its native message-list variable', async () => {
+    const manifests = await new BundledCatalogPluginSource().list();
+    const deepseekWidth = manifests.find(
+      (plugin) => plugin.id === 'voyager.deepseek-reading-width',
+    );
+    const file = '../catalog/plugins/deepseek-reading-width/style.css';
+    const css = readFileSync(new URL(file, import.meta.url), 'utf8');
+
+    expect(deepseekWidth?.matches).toEqual(['https://chat.deepseek.com/*']);
+    expect(deepseekWidth?.contributes.settings?.width).toEqual({
+      type: 'number',
+      label: 'Reading width (px)',
+      minLabel: 'Narrower',
+      maxLabel: 'Wider',
+      default: 712,
+      min: 600,
+      max: 1600,
+    });
+    expect(deepseekWidth?.contributes.domOps).toContainEqual({
+      op: 'setStyle',
+      target: { kind: 'css', selector: 'body' },
+      styles: { '--message-list-max-width': '{{width}}px' },
+    });
+    expect(css).toContain('.gv-plugin-deepseek-readable');
+    expect(css).toContain('--message-list-max-width: var(--gv-plugin-reading-width, 712px)');
+    expect(css).toContain('.ds-virtual-list');
   });
 
   it('widens Claude document artifacts inside their cross-origin frame', async () => {
@@ -120,6 +150,7 @@ describe('BundledCatalogPluginSource', () => {
       'https://chat.openai.com/*',
       'https://chatgpt.com/*',
       'https://claude.ai/*',
+      'https://chat.deepseek.com/*',
     ]);
   });
 });

--- a/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
+++ b/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
@@ -147,10 +147,10 @@ describe('BundledCatalogPluginSource', () => {
 
     expect(pluginsToOriginPatterns(manifests)).toEqual([
       'https://*.frame.claudeusercontent.com/*',
+      'https://chat.deepseek.com/*',
       'https://chat.openai.com/*',
       'https://chatgpt.com/*',
       'https://claude.ai/*',
-      'https://chat.deepseek.com/*',
     ]);
   });
 });

--- a/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
+++ b/src/features/plugins/sources/BundledCatalogPluginSource.test.ts
@@ -67,7 +67,7 @@ describe('BundledCatalogPluginSource', () => {
     expect(centeredTurnRule).toBeGreaterThan(footerOverride);
   });
 
-  it('supports DeepSeek reading width through its native message-list variable', async () => {
+  it('supports a scoped DeepSeek reading width setting', async () => {
     const manifests = await new BundledCatalogPluginSource().list();
     const deepseekWidth = manifests.find(
       (plugin) => plugin.id === 'voyager.deepseek-reading-width',
@@ -88,10 +88,10 @@ describe('BundledCatalogPluginSource', () => {
     expect(deepseekWidth?.contributes.domOps).toContainEqual({
       op: 'setStyle',
       target: { kind: 'css', selector: 'body' },
-      styles: { '--message-list-max-width': '{{width}}px' },
+      styles: { '--gv-plugin-reading-width': '{{width}}px' },
     });
     expect(css).toContain('.gv-plugin-deepseek-readable');
-    expect(css).toContain('--message-list-max-width: var(--gv-plugin-reading-width, 712px)');
+    expect(css).toContain('var(--gv-plugin-reading-width, 712px)');
     expect(css).toContain('.ds-virtual-list');
   });
 

--- a/src/features/plugins/sources/BundledCatalogPluginSource.ts
+++ b/src/features/plugins/sources/BundledCatalogPluginSource.ts
@@ -7,6 +7,8 @@ import claudeCjkRenderFixManifest from '../catalog/plugins/claude-cjk-render-fix
 import claudeCjkRenderFixStyle from '../catalog/plugins/claude-cjk-render-fix/style.css?raw';
 import claudeReadingWidthManifest from '../catalog/plugins/claude-reading-width/plugin.json?raw';
 import claudeReadingWidthStyle from '../catalog/plugins/claude-reading-width/style.css?raw';
+import deepseekReadingWidthManifest from '../catalog/plugins/deepseek-reading-width/plugin.json?raw';
+import deepseekReadingWidthStyle from '../catalog/plugins/deepseek-reading-width/style.css?raw';
 import { validateManifest } from '../manifest/validate';
 import type { PluginManifest, PluginSource } from '../types';
 import { resolveStyleFileContributions } from './styleFiles';
@@ -38,6 +40,10 @@ const BUNDLED_PLUGIN_FILES: Readonly<Record<string, BundledPluginFiles>> = {
   'plugins/chatgpt-reading-width/plugin.json': {
     manifestJson: chatgptReadingWidthManifest,
     styles: { 'style.css': chatgptReadingWidthStyle },
+  },
+  'plugins/deepseek-reading-width/plugin.json': {
+    manifestJson: deepseekReadingWidthManifest,
+    styles: { 'style.css': deepseekReadingWidthStyle },
   },
 };
 

--- a/src/features/plugins/sources/deepseekReadingWidth.test.ts
+++ b/src/features/plugins/sources/deepseekReadingWidth.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DeclarativeEngine } from '../runtime/declarativeEngine';
+import { deepseekAdapter } from '../sites/adapters/deepseek';
+import { BundledCatalogPluginSource } from './BundledCatalogPluginSource';
+
+afterEach(() => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+  document.body.removeAttribute('style');
+  document.body.removeAttribute('class');
+});
+
+describe('DeepSeek reading width lifecycle', () => {
+  it('updates settings and restores host state through repeated mount cycles', async () => {
+    const manifest = (await new BundledCatalogPluginSource().list()).find(
+      (entry) => entry.id === 'voyager.deepseek-reading-width',
+    );
+    if (!manifest) throw new Error('Missing bundled DeepSeek plugin');
+    document.body.className = 'zh_CN light';
+    document.body.style.setProperty('--message-list-max-width', '840px');
+    document.body.style.setProperty('--gv-plugin-reading-width', '900px');
+    const engine = new DeclarativeEngine({ doc: document, adapter: deepseekAdapter });
+    try {
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        engine.mount(manifest, { width: 1100 });
+        expect(document.body.classList.contains('gv-plugin-deepseek-readable')).toBe(true);
+        expect(document.body.style.getPropertyValue('--gv-plugin-reading-width')).toBe('1100px');
+        engine.updateSettings(manifest.id, { width: 600 });
+        expect(document.body.style.getPropertyValue('--gv-plugin-reading-width')).toBe('600px');
+        expect(document.body.style.getPropertyValue('--message-list-max-width')).toBe('840px');
+        engine.unmount(manifest.id);
+        expect(document.body.className).toBe('zh_CN light');
+        expect(document.body.style.getPropertyValue('--gv-plugin-reading-width')).toBe('900px');
+        expect(document.getElementById('gv-plugin-style-' + manifest.id)).toBeNull();
+      }
+    } finally {
+      engine.unmount(manifest.id);
+    }
+  });
+});


### PR DESCRIPTION
## Scope

Add an opt-in bundled CSS/JSON reading-width plugin for `chat.deepseek.com` using the existing catalog, optional host access and plugin settings. Localized width setting: 600–1600px, default 712px. Scope sizing to the printable message list, preserve the native composer and vertical virtualization, and restore prior styles on disable.

## Related issue

Closes #961

## Notes

Width is bounded to the chat viewport so the plugin cannot overflow the DeepSeek layout at narrow window sizes.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
