### PR TITLE
fix(plugins): display DeepSeek branding in the plugin manager

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -69,14 +69,15 @@ export function platformBadge(
   const brand = plugin.theme?.brand;
   const current = currentSiteId ? SITE_BADGES[currentSiteId] : undefined;
   if (current) return { icon: <current.Icon />, color: brand ?? current.color };
-  const host = plugin.matches
-    .map((m) => m.replace(/^[a-z*]+:\/\//i, '').replace(/\/.*$/, ''))
-    .join(' ');
-  if (host.includes('claude.ai'))
+  const hosts = plugin.matches.flatMap((pattern) => {
+    const match = /^(?:https?|\*):\/\/([^/]+)\//i.exec(pattern);
+    return match ? [match[1]] : [];
+  });
+  if (hosts.includes('claude.ai'))
     return { icon: <IconClaude />, color: brand ?? SITE_BADGES.claude.color };
-  if (host.includes('chatgpt.com') || host.includes('openai.com'))
+  if (hosts.includes('chatgpt.com') || hosts.includes('chat.openai.com'))
     return { icon: <IconChatGPT />, color: brand ?? SITE_BADGES.chatgpt.color };
-  if (plugin.matches.some((pattern) => pattern.startsWith('https://chat.deepseek.com/')))
+  if (hosts.includes('chat.deepseek.com'))
     return { icon: <IconDeepSeek />, color: brand ?? SITE_BADGES.deepseek.color };
   return null;
 }

--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -23,7 +23,7 @@ import type { PluginManifest, PluginSettingValue, SettingField } from '@/feature
 import { Card, CardContent, CardTitle } from '../../../components/ui/card';
 import { Switch } from '../../../components/ui/switch';
 import { useLanguage } from '../../../contexts/LanguageContext';
-import { IconChatGPT, IconClaude } from './WebsiteLogos';
+import { IconChatGPT, IconClaude, IconDeepSeek } from './WebsiteLogos';
 
 type EnabledMap = Record<string, boolean>;
 type SettingsMap = Record<string, Record<string, PluginSettingValue>>;
@@ -52,6 +52,7 @@ async function requestPluginContentScriptSync(): Promise<boolean> {
 const SITE_BADGES: Record<string, { Icon: typeof IconClaude; color: string }> = {
   claude: { Icon: IconClaude, color: '#d97757' },
   chatgpt: { Icon: IconChatGPT, color: '#0ea5e9' },
+  deepseek: { Icon: IconDeepSeek, color: '#4d6bfe' },
 };
 
 /**
@@ -75,6 +76,8 @@ export function platformBadge(
     return { icon: <IconClaude />, color: brand ?? SITE_BADGES.claude.color };
   if (host.includes('chatgpt.com') || host.includes('openai.com'))
     return { icon: <IconChatGPT />, color: brand ?? SITE_BADGES.chatgpt.color };
+  if (plugin.matches.some((pattern) => pattern.startsWith('https://chat.deepseek.com/')))
+    return { icon: <IconDeepSeek />, color: brand ?? SITE_BADGES.deepseek.color };
   return null;
 }
 

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PluginManifest } from '@/features/plugins/types';
 
 import { PluginManager, platformBadge } from '../PluginManager';
+import { IconDeepSeek } from '../WebsiteLogos';
 
 // The slider-debounce behaviour under test lives in PluginManager; the storage
 // layer is mocked so we can assert exactly how often (and with what value) the
@@ -433,6 +434,37 @@ describe('platformBadge', () => {
     expect(platformBadge(formulaCopy, 'chatgpt')?.color).toBe('#0ea5e9');
     expect(platformBadge(formulaCopy, 'claude')?.color).toBe('#d97757');
   });
+
+  it('uses the bundled DeepSeek icon and accent for the active platform', () => {
+    const plugin = {
+      ...formulaCopy,
+      matches: [...formulaCopy.matches, 'https://chat.deepseek.com/*'],
+    };
+    const badge = platformBadge(plugin, 'deepseek');
+    expect(badge?.color).toBe('#4d6bfe');
+    expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
+  });
+
+  it('recognizes a DeepSeek-only plugin before a site adapter is available', () => {
+    const badge = platformBadge({ ...formulaCopy, matches: ['https://chat.deepseek.com/*'] });
+    expect(badge?.color).toBe('#4d6bfe');
+    expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
+  });
+
+  it('preserves a DeepSeek plugin custom accent', () => {
+    const plugin = {
+      ...formulaCopy,
+      matches: ['https://chat.deepseek.com/*'],
+      theme: { brand: '#123456' },
+    };
+    expect(platformBadge(plugin)?.color).toBe('#123456');
+    expect(platformBadge(plugin, 'deepseek')?.color).toBe('#123456');
+  });
+
+  it.each(['https://chat.deepseek.com.example.org/*', 'https://example.org/chat.deepseek.com/*'])(
+    'does not mislabel unrelated matches %s as DeepSeek',
+    (pattern) => expect(platformBadge({ ...formulaCopy, matches: [pattern] })).toBeNull(),
+  );
 
   it('prefers the plugin-declared theme.brand over the site default', () => {
     const themed = { ...formulaCopy, theme: { brand: '#123456' } };

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -467,8 +467,31 @@ describe('platformBadge', () => {
   );
 
   it('prefers the plugin-declared theme.brand over the site default', () => {
+    // Existing platforms retain their own fallback colour.
     const themed = { ...formulaCopy, theme: { brand: '#123456' } };
     expect(platformBadge(themed, 'chatgpt')?.color).toBe('#123456');
+  });
+
+  it.each([
+    'https://notclaude.ai/*',
+    'https://claude.ai.example.org/*',
+    'https://notchatgpt.com/*',
+    'https://chat.openai.com.example.org/*',
+    'https://api.openai.com/*',
+    'https://example.org/claude.ai/*',
+  ])('does not infer an official chat platform from %s', (pattern) => {
+    expect(platformBadge({ ...formulaCopy, matches: [pattern] })).toBeNull();
+  });
+
+  it.each([
+    ['https://claude.ai/*', '#d97757'],
+    ['https://chatgpt.com/*', '#0ea5e9'],
+    ['https://chat.openai.com/*', '#0ea5e9'],
+    ['*://chatgpt.com/*', '#0ea5e9'],
+    ['http://chat.deepseek.com/*', '#4d6bfe'],
+    ['*://chat.deepseek.com/*', '#4d6bfe'],
+  ])('recognizes the exact chat host in %s', (pattern, color) => {
+    expect(platformBadge({ ...formulaCopy, matches: [pattern] })?.color).toBe(color);
   });
 
   it('falls back to the first matched host when the current site is unknown', () => {


### PR DESCRIPTION
## Scope

Show DeepSeek branding for DeepSeek plugins in the popup plugin manager, and match platform badges against exact chat hosts so an unrelated host cannot pick up a platform badge.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
