### PR TITLE
fix(plugins): retain accessible platform and setting context

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -496,6 +496,7 @@ export function PluginManager({
                     onClick={() => toggleCollapsed(plugin.id)}
                     className="group flex w-full items-start gap-1.5 text-left"
                     aria-expanded={isOpen}
+                    aria-label={localizedName}
                   >
                     <svg
                       width="11"
@@ -563,7 +564,7 @@ export function PluginManager({
                       companion-frame grant must not disable settings that still affect the
                       already-authorized parent page. */}
                   {enabled && settingsSchema && (
-                    <div className="mt-2 space-y-2.5">
+                    <div className="mt-2 space-y-2.5" role="group" aria-label={localizedName}>
                       {Object.entries(settingsSchema).map(([key, field]) => {
                         const rawValue = settingsMap[plugin.id]?.[key] ?? field.default;
                         const settingText = pickLocalizedSetting(plugin, key, field, language);

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -245,6 +245,47 @@ describe('PluginManager boolean setting', () => {
   });
 });
 
+describe('PluginManager accessible plugin identity', () => {
+  it('keeps the complete localized platform name on collapsed headers', async () => {
+    mockLanguage.current = 'zh';
+    const plugin: PluginManifest = {
+      ...widthPlugin,
+      name: 'Claude · Reading width',
+      i18n: { zh: { name: 'Claude · 阅读宽度' } },
+    };
+    await render(plugin);
+    const header = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    expect(header?.getAttribute('aria-label')).toBe('Claude · 阅读宽度');
+    expect(header?.getAttribute('aria-expanded')).toBe('true');
+    act(() => header?.click());
+    expect(header?.getAttribute('aria-expanded')).toBe('false');
+    expect(header?.getAttribute('aria-label')).toBe('Claude · 阅读宽度');
+  });
+
+  it('groups identically named controls under their owning plugins', async () => {
+    const second: PluginManifest = {
+      ...widthPlugin,
+      id: 'voyager.second-width',
+      name: 'ChatGPT · Width',
+      matches: ['https://chatgpt.com/*'],
+    };
+    pluginState.current[second.id] = { enabled: true, installedAt: 0 };
+    await act(async () => {
+      root.render(React.createElement(PluginManager, { manifests: [widthPlugin, second] }));
+    });
+    const groups = Array.from(container.querySelectorAll('[role="group"]'));
+    expect(groups.map((group) => group.getAttribute('aria-label'))).toEqual([
+      'Test · Width',
+      'ChatGPT · Width',
+    ]);
+    for (const group of groups) {
+      expect(group.querySelector('input[type="range"]')?.getAttribute('aria-label')).toBe(
+        'Reading width (px)',
+      );
+    }
+  });
+});
+
 describe('PluginManager host permission flow', () => {
   beforeEach(() => {
     pluginState.current = { [PLUGIN_ID]: { enabled: false, installedAt: 0 } };


### PR DESCRIPTION
## Scope

Keep the accessible name of a repeated plugin setting tied to its platform and setting context, so screen-reader users can tell two identically labelled settings apart in the plugin manager.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
