### PR TITLE
test(theme): cover DeepSeek platform branding

### DIFF
--- a/src/pages/content/platformTheme/__tests__/platformTheme.test.ts
+++ b/src/pages/content/platformTheme/__tests__/platformTheme.test.ts
@@ -37,10 +37,11 @@ const themedPlugin = (brand: string, matches: string[]): PluginManifest => ({
 });
 
 describe('resolveBrandColor', () => {
-  it('uses the adapter brandColor for Claude and ChatGPT', () => {
+  it('uses the adapter brandColor for Claude, ChatGPT and DeepSeek', () => {
     expect(resolveBrandColor('https://claude.ai/chat/1')).toBe('#d97757');
     expect(resolveBrandColor('https://chatgpt.com/c/1')).toBe('#0ea5e9');
     expect(resolveBrandColor('https://chat.openai.com/')).toBe('#0ea5e9');
+    expect(resolveBrandColor('https://chat.deepseek.com/a/chat/s/1')).toBe('#4d6bfe');
   });
 
   it('returns null for Gemini / AI Studio / unknown sites', () => {
@@ -83,6 +84,10 @@ describe('effectiveAccentForDisplay', () => {
     expect(effectiveAccentForDisplay('https://gemini.google.com/app')).toBe(DEFAULT_ACCENT);
   });
 
+  it('returns the DeepSeek adapter colour for a plugin-platform page', () => {
+    expect(effectiveAccentForDisplay('https://chat.deepseek.com/a/chat/s/1')).toBe('#4d6bfe');
+  });
+
   it('returns the adapter colour for Claude and the override when set', () => {
     expect(effectiveAccentForDisplay('https://claude.ai/x')).toBe('#d97757');
     expect(effectiveAccentForDisplay('https://claude.ai/x', [], { claude: '#0f0f0f' })).toBe(
@@ -121,6 +126,13 @@ describe('applyBrandTheme', () => {
     applyBrandTheme('https://claude.ai/x', [], document);
     expect(document.documentElement.classList.contains(PLATFORM_THEME_CLASS)).toBe(true);
     expect(document.documentElement.style.getPropertyValue('--gv-pm-brand')).toBe('#d97757');
+  });
+
+  it('applies the DeepSeek adapter colour to the Voyager UI root', () => {
+    applyBrandTheme('https://chat.deepseek.com/a/chat/s/1', [], document);
+    expect(document.documentElement.classList.contains(PLATFORM_THEME_CLASS)).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--gv-pm-brand')).toBe('#4d6bfe');
+    expect(document.documentElement.style.getPropertyValue('--gv-pm-brand-fg')).toBe('#ffffff');
   });
 
   it('adds nothing on Gemini', () => {


### PR DESCRIPTION
## Scope

Test-only: cover DeepSeek platform branding in the content-script platform theme, so the descriptor stays correct as platforms are added.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
