### PR TITLE
fix(plugins): normalize DeepSeek plugin names

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -84,7 +84,7 @@ export function platformBadge(
 
 /** Strip a redundant "Claude · " / "ChatGPT · " platform prefix (the logo shows it). */
 function displayName(name: string): string {
-  return name.replace(/^(Claude|ChatGPT|Gemini|AI Studio)\s*[·:|]\s*/i, '');
+  return name.replace(/^(Claude|ChatGPT|Gemini|AI Studio|DeepSeek)\s*[·:|]\s*/i, '');
 }
 
 /**

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -540,3 +540,17 @@ describe('platformBadge', () => {
     expect(platformBadge(formulaCopy, undefined)?.color).toBe('#d97757');
   });
 });
+
+describe('PluginManager platform name display', () => {
+  it('removes the DeepSeek prefix when the platform badge is shown', async () => {
+    const plugin: PluginManifest = {
+      ...widthPlugin,
+      name: 'DeepSeek · Comfortable Reading Width',
+      matches: ['https://chat.deepseek.com/*'],
+    };
+    await render(plugin);
+    const header = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    expect(header?.textContent).toContain('Comfortable Reading Width');
+    expect(header?.textContent).not.toContain('DeepSeek ·');
+  });
+});


### PR DESCRIPTION
## Scope

Normalize DeepSeek plugin display names in the plugin manager so bundled catalog entries read consistently with the rest of the list.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
