### PR TITLE
fix(plugins): scope platform badges to the active site

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/core/utils/browser';
 import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
 import { pluginToOriginPatternsForActiveUrl } from '@/features/plugins/runtime/siteRegistration';
+import { matchesAnyPattern } from '@/features/plugins/sites/matchPattern';
 import { SiteRegistry } from '@/features/plugins/sites/registry';
 import {
   loadCollapsedPlugins,
@@ -65,8 +66,10 @@ const SITE_BADGES: Record<string, { Icon: typeof IconClaude; color: string }> = 
 export function platformBadge(
   plugin: PluginManifest,
   currentSiteId?: string,
+  activeUrl?: string,
 ): { icon: ReactNode; color: string } | null {
   const brand = plugin.theme?.brand;
+  if (activeUrl && !matchesAnyPattern(activeUrl, plugin.matches)) return null;
   const current = currentSiteId ? SITE_BADGES[currentSiteId] : undefined;
   if (current) return { icon: <current.Icon />, color: brand ?? current.color };
   const hosts = plugin.matches.flatMap((pattern) => {
@@ -483,7 +486,7 @@ export function PluginManager({
           const isOpen = !collapsed.has(plugin.id);
           const hosts = siteHostsFromMatches(plugin.matches);
           const settingsSchema = plugin.contributes.settings;
-          const badge = platformBadge(plugin, currentSiteId);
+          const badge = platformBadge(plugin, currentSiteId, activeUrl);
           const localizedName = pickLocalized(plugin, 'name', language);
           const needsSiteAccess = enabled && missingPermissionIds.has(plugin.id);
           return (

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -486,6 +486,15 @@ describe('platformBadge', () => {
     expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
   });
 
+  it('does not use the active DeepSeek badge for a plugin that excludes DeepSeek', () => {
+    const badge = platformBadge(
+      { ...formulaCopy, matches: ['https://claude.ai/*'] },
+      'deepseek',
+      'https://chat.deepseek.com/a/chat/s/current',
+    );
+    expect(badge).toBeNull();
+  });
+
   it('recognizes a DeepSeek-only plugin before a site adapter is available', () => {
     const badge = platformBadge({ ...formulaCopy, matches: ['https://chat.deepseek.com/*'] });
     expect(badge?.color).toBe('#4d6bfe');


### PR DESCRIPTION
## Scope

Scope platform badges to the active site, so a plugin badge is only shown where that platform actually applies.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
