### PR TITLE
docs(plugins): mention DeepSeek in the bundled catalog

### DIFF
--- a/src/features/plugins/README.md
+++ b/src/features/plugins/README.md
@@ -2,7 +2,7 @@
 
 A self-contained subsystem that lets Voyager run **plugins** — units that inject
 styles / DOM changes into AI chat sites (Gemini, AI Studio, ChatGPT, Claude,
-…). Voyager's own features can migrate onto this over time; third parties
+DeepSeek, …). Voyager's own features can migrate onto this over time; third parties
 can ship their own plugins against the same contract.
 
 ## Two design constraints that shaped everything
@@ -106,9 +106,9 @@ prefixed (content-script rule).
 
 ## What is NOT done yet (next milestones)
 
-- **Full setting UI coverage.** The schema accepts boolean/string/color/select,
-  but the popup currently renders the number/range control used by the official
-  width plugins.
+- **Full setting UI coverage.** The schema accepts boolean/string/color/select;
+  the popup currently renders boolean switches and number/range controls, while
+  string, color and select controls remain future work.
 - **Scripted runtime** via gated `chrome.userScripts`.
 - **Account + Stripe entitlement**.
 

--- a/src/features/plugins/catalog/marketplace.json
+++ b/src/features/plugins/catalog/marketplace.json
@@ -6,7 +6,7 @@
     "name": "voyager-official",
     "url": "https://github.com/Nagi-ovo/voyager"
   },
-  "description": "Bundled official plugin catalog for Voyager — declarative plugins that enhance AI chat sites (Claude, ChatGPT, …).",
+  "description": "Bundled official plugin catalog for Voyager — declarative plugins that enhance AI chat sites (Claude, ChatGPT, DeepSeek, …).",
   "plugins": [
     {
       "name": "claude-cjk-render-fix",


### PR DESCRIPTION
## Scope

Docs-only: update the plugin README's platform and settings coverage, and mention DeepSeek in the bundled catalog description.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
