### PR TITLE
test(plugins): guard DeepSeek permission scope

### DIFF
--- a/src/features/plugins/runtime/siteRegistration.test.ts
+++ b/src/features/plugins/runtime/siteRegistration.test.ts
@@ -47,6 +47,7 @@ describe('pluginsToOriginPatterns', () => {
 
 describe('pluginToOriginPatternsForActiveUrl', () => {
   const chatgptPlugin = mk(['https://chatgpt.com/*', 'https://chat.openai.com/*']);
+  const deepseekPlugin = mk(['https://chat.deepseek.com/*', 'https://chat.deepseek.com/a/chat/*']);
   const claudeArtifactPlugin = mk([
     'https://claude.ai/*',
     'https://*.frame.claudeusercontent.com/*',
@@ -74,6 +75,21 @@ describe('pluginToOriginPatternsForActiveUrl', () => {
         'https://claude.ai/code/artifact/example',
       ),
     ).toEqual(['https://*.frame.claudeusercontent.com/*', 'https://claude.ai/*']);
+  });
+
+  it('requests only the DeepSeek chat origin from a DeepSeek page', () => {
+    expect(
+      pluginToOriginPatternsForActiveUrl(
+        deepseekPlugin,
+        'https://chat.deepseek.com/a/chat/s/current',
+      ),
+    ).toEqual(['https://chat.deepseek.com/*']);
+  });
+
+  it('does not expand DeepSeek permission scope for an unrelated active page', () => {
+    expect(pluginToOriginPatternsForActiveUrl(deepseekPlugin, 'https://example.com/')).toEqual([
+      'https://chat.deepseek.com/*',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Scope

Test-only: guard the DeepSeek permission scope in `siteRegistration`, so the platform cannot silently gain a broader origin grant than it declares.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
