### PR TITLE
test(popup): cover DeepSeek plugin-only mode

### DIFF
--- a/src/pages/popup/utils/siteMode.test.ts
+++ b/src/pages/popup/utils/siteMode.test.ts
@@ -8,6 +8,7 @@ describe('isPluginPopupSite', () => {
     expect(isPluginPopupSite('https://chat.openai.com/c/abc', [])).toBe(true);
     expect(isPluginPopupSite('https://claude.ai/chat/abc', [])).toBe(true);
     expect(isPluginPopupSite('https://grok.com/', [])).toBe(true);
+    expect(isPluginPopupSite('https://chat.deepseek.com/a/chat/s/abc', [])).toBe(true);
   });
 
   it('keeps native sites on the full popup even if manifests target them', () => {


### PR DESCRIPTION
## Scope

Test-only: cover DeepSeek in the popup's plugin-only site mode, so the popup keeps hiding Gemini-native controls on a plugin-only platform.

---

Contributed by @ccch1mneyyy. The branches were prepared in `ccch1mneyyy/voyager` and mirrored into this repository by @Nagi-ovo because [GitHub stacks do not support cross-fork chains](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests). Every commit keeps its original authorship.
