### PR TITLE
feat(plugins): add DeepSeek platform adapter

### DIFF
--- a/src/features/plugins/sites/adapters/deepseek.test.ts
+++ b/src/features/plugins/sites/adapters/deepseek.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { deepseekAdapter } from './deepseek';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('class');
+});
+
+describe('DeepSeek content markers', () => {
+  it('distinguishes user, thinking-only, final and empty virtual turns', () => {
+    document.body.innerHTML =
+      '<div class="ds-message" id="user"><div class="ds-collapsible-text">Example</div></div>' +
+      '<div class="ds-message" id="thinking"><div class="ds-think-content">Working</div></div>' +
+      '<div class="ds-message" id="answer"><div class="ds-assistant-message-main-content">Answer</div></div>' +
+      '<div class="ds-message" id="pending"></div>' +
+      '<div class="ds-collapsible-text">Unrelated preview</div>';
+    const ids = (selector: string) =>
+      Array.from(document.querySelectorAll(selector), (el) => el.id);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    document
+      .querySelector('#thinking')
+      ?.insertAdjacentHTML(
+        'beforeend',
+        '<div class="ds-assistant-message-main-content">Finished</div>',
+      );
+    expect(ids(deepseekAdapter.selectors.assistantTurn)).toEqual(['thinking', 'answer']);
+    expect(ids(deepseekAdapter.selectors.userTurn)).toEqual(['user']);
+  });
+
+  it('finds the composer without matching unrelated editors', () => {
+    document.body.innerHTML =
+      '<textarea placeholder="Search"></textarea>' +
+      '<textarea class="ds-scroll-area" placeholder="Message DeepSeek" id="composer"></textarea>' +
+      '<div contenteditable="true"></div>';
+    expect(document.querySelectorAll(deepseekAdapter.selectors.composer)).toHaveLength(1);
+    expect(document.querySelector(deepseekAdapter.selectors.composer)?.id).toBe('composer');
+  });
+
+  it.each(['light', 'dark'])('recognizes the body %s theme', (theme) => {
+    document.body.className = 'zh_CN ' + theme;
+    expect(document.querySelector(deepseekAdapter.theme.hostSelector)).toBe(document.body);
+    expect(document.querySelector(deepseekAdapter.theme.lightSelector) !== null).toBe(
+      theme === 'light',
+    );
+    expect(document.querySelector(deepseekAdapter.theme.darkSelector) !== null).toBe(
+      theme === 'dark',
+    );
+  });
+});

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -4,18 +4,18 @@ import type { SiteAdapter, SiteCapability } from '../../types';
  * DeepSeek web app adapter (chat.deepseek.com).
  *
  * DeepSeek renders both user and assistant turns as ds-message elements.
- * Assistant turns expose ds-assistant-message-main-content; using that
- * stable semantic marker keeps the user selector independent of hashed classes.
+ * Match positive content markers: an unfinished assistant turn must never
+ * become a user turn simply because its final answer has not mounted yet.
  */
 export const deepseekAdapter: SiteAdapter = {
   id: 'deepseek',
   label: 'DeepSeek',
   matches: ['https://chat.deepseek.com/*'],
   selectors: {
-    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
-    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
-    sidebar: 'nav, aside',
+    userTurn:
+      '.ds-message:has(.ds-collapsible-text):not(:has(.ds-assistant-message-main-content, .ds-think-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content, .ds-think-content)',
+    composer: 'textarea.ds-scroll-area[placeholder*="DeepSeek" i]',
   },
   theme: {
     hostSelector: 'body',
@@ -23,5 +23,5 @@ export const deepseekAdapter: SiteAdapter = {
     darkSelector: 'body.dark',
   },
   brandColor: '#4d6bfe',
-  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+  capabilities: new Set<SiteCapability>(['chat', 'composer', 'darkMode']),
 };

--- a/src/features/plugins/sites/adapters/deepseek.ts
+++ b/src/features/plugins/sites/adapters/deepseek.ts
@@ -1,0 +1,27 @@
+import type { SiteAdapter, SiteCapability } from '../../types';
+
+/**
+ * DeepSeek web app adapter (chat.deepseek.com).
+ *
+ * DeepSeek renders both user and assistant turns as ds-message elements.
+ * Assistant turns expose ds-assistant-message-main-content; using that
+ * stable semantic marker keeps the user selector independent of hashed classes.
+ */
+export const deepseekAdapter: SiteAdapter = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+  matches: ['https://chat.deepseek.com/*'],
+  selectors: {
+    userTurn: '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    assistantTurn: '.ds-message:has(.ds-assistant-message-main-content)',
+    composer: 'textarea[placeholder*="DeepSeek"], textarea[placeholder*="Deepseek"]',
+    sidebar: 'nav, aside',
+  },
+  theme: {
+    hostSelector: 'body',
+    lightSelector: 'body.light',
+    darkSelector: 'body.dark',
+  },
+  brandColor: '#4d6bfe',
+  capabilities: new Set<SiteCapability>(['chat', 'sidebar', 'composer', 'darkMode']),
+};

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -14,6 +14,7 @@ describe('SiteRegistry.resolveByUrl', () => {
     expect(
       registry.resolveByUrl('https://artifact-id.frame.claudeusercontent.com/_f/version/')?.id,
     ).toBe('claude');
+    expect(registry.resolveByUrl('https://chat.deepseek.com/a/chat/s/abc')?.id).toBe('deepseek');
   });
 
   it('returns null for sites with no adapter', () => {
@@ -29,6 +30,8 @@ describe('resolvePluginPlatformId', () => {
     expect(
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
+    expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
+    expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 
   it('returns null for native Voyager sites (full feature set runs there)', () => {

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -50,21 +49,17 @@ describe('resolvePluginPlatformId', () => {
   });
 });
 
-describe('deepseekAdapter', () => {
-  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
-    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
-    expect(deepseekAdapter.selectors.userTurn).toBe(
-      '.ds-message:not(:has(.ds-assistant-message-main-content))',
-    );
-    expect(deepseekAdapter.selectors.assistantTurn).toBe(
-      '.ds-message:has(.ds-assistant-message-main-content)',
-    );
-    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
-    expect(deepseekAdapter.theme).toEqual({
-      hostSelector: 'body',
-      lightSelector: 'body.light',
-      darkSelector: 'body.dark',
-    });
-    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
+describe('DeepSeek URL boundaries', () => {
+  it.each(['https://chat.deepseek.com/', 'https://chat.deepseek.com/a/chat/s/example?x=1#last'])(
+    'resolves %s as a plugin-only platform',
+    (url) => expect(resolvePluginPlatformId(url)).toBe('deepseek'),
+  );
+  it.each([
+    'https://deepseek.com/',
+    'https://api.deepseek.com/',
+    'https://chat.deepseek.com.example.org/',
+    'http://chat.deepseek.com/',
+  ])('does not grant platform support to %s', (url) => {
+    expect(SiteRegistry.createDefault().resolveByUrl(url)).toBeNull();
   });
 });

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -30,7 +30,6 @@ describe('resolvePluginPlatformId', () => {
     expect(
       resolvePluginPlatformId('https://artifact-id.frame.claudeusercontent.com/_f/version/'),
     ).toBe('claude');
-    expect(resolvePluginPlatformId('https://grok.com/')).toBe('grok');
     expect(resolvePluginPlatformId('https://chat.deepseek.com/a/chat/s/abc')).toBe('deepseek');
   });
 

--- a/src/features/plugins/sites/registry.test.ts
+++ b/src/features/plugins/sites/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { deepseekAdapter } from './adapters/deepseek';
 import { NATIVE_SITE_IDS, SiteRegistry, resolvePluginPlatformId } from './registry';
 
 describe('SiteRegistry.resolveByUrl', () => {
@@ -46,5 +47,24 @@ describe('resolvePluginPlatformId', () => {
     expect(resolvePluginPlatformId('https://example.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://deepseek.com/')).toBeNull();
     expect(resolvePluginPlatformId('https://grok.com/')).toBeNull();
+  });
+});
+
+describe('deepseekAdapter', () => {
+  it('exposes selectors and capabilities for the observed DeepSeek layout', () => {
+    expect(deepseekAdapter.matches).toEqual(['https://chat.deepseek.com/*']);
+    expect(deepseekAdapter.selectors.userTurn).toBe(
+      '.ds-message:not(:has(.ds-assistant-message-main-content))',
+    );
+    expect(deepseekAdapter.selectors.assistantTurn).toBe(
+      '.ds-message:has(.ds-assistant-message-main-content)',
+    );
+    expect(deepseekAdapter.selectors.composer).toContain('textarea[placeholder*="DeepSeek"]');
+    expect(deepseekAdapter.theme).toEqual({
+      hostSelector: 'body',
+      lightSelector: 'body.light',
+      darkSelector: 'body.dark',
+    });
+    expect([...deepseekAdapter.capabilities]).toEqual(['chat', 'sidebar', 'composer', 'darkMode']);
   });
 });

--- a/src/features/plugins/sites/registry.ts
+++ b/src/features/plugins/sites/registry.ts
@@ -9,6 +9,7 @@ import type { SiteAdapter, SiteId } from '../types';
 import { aistudioAdapter } from './adapters/aistudio';
 import { chatgptAdapter } from './adapters/chatgpt';
 import { claudeAdapter } from './adapters/claude';
+import { deepseekAdapter } from './adapters/deepseek';
 import { geminiAdapter } from './adapters/gemini';
 import { matchesAnyPattern } from './matchPattern';
 
@@ -17,12 +18,13 @@ export const DEFAULT_ADAPTERS: readonly SiteAdapter[] = [
   aistudioAdapter,
   chatgptAdapter,
   claudeAdapter,
+  deepseekAdapter,
 ];
 
 /**
  * Site ids Voyager treats as first-party "native" surfaces — these get the full
  * Gemini Voyager feature set (Timeline, Folders, Prompt Manager, …). Every other
- * adapter (Claude / ChatGPT) is a *plugin platform*: declarative plugins
+ * adapter (Claude / ChatGPT / DeepSeek) is a *plugin platform*: declarative plugins
  * + platform theming only, never core Gemini features.
  */
 export const NATIVE_SITE_IDS: ReadonlySet<SiteId> = new Set<SiteId>(['gemini', 'aistudio']);
@@ -54,7 +56,7 @@ export class SiteRegistry {
 }
 
 /**
- * Resolve the id of a third-party *plugin platform* for a URL (Claude / ChatGPT),
+ * Resolve the id of a third-party *plugin platform* for a URL (Claude / ChatGPT / DeepSeek),
  * or `null` when the URL is a native Voyager site (Gemini / AI Studio)
  * or has no adapter at all. The content script uses this to keep core Gemini
  * features off plugin-only platforms while still running the plugin host + theme.

--- a/src/features/plugins/types.ts
+++ b/src/features/plugins/types.ts
@@ -19,7 +19,13 @@
 // Sites
 // ---------------------------------------------------------------------------
 
-export const KNOWN_SITE_IDS = ['gemini', 'aistudio', 'chatgpt', 'claude'] as const;
+export const KNOWN_SITE_IDS = [
+  'gemini',
+  'aistudio',
+  'chatgpt',
+  'claude',
+  'deepseek',
+] as const;
 export type KnownSiteId = (typeof KNOWN_SITE_IDS)[number];
 
 /**

--- a/src/features/plugins/types.ts
+++ b/src/features/plugins/types.ts
@@ -19,13 +19,7 @@
 // Sites
 // ---------------------------------------------------------------------------
 
-export const KNOWN_SITE_IDS = [
-  'gemini',
-  'aistudio',
-  'chatgpt',
-  'claude',
-  'deepseek',
-] as const;
+export const KNOWN_SITE_IDS = ['gemini', 'aistudio', 'chatgpt', 'claude', 'deepseek'] as const;
 export type KnownSiteId = (typeof KNOWN_SITE_IDS)[number];
 
 /**


### PR DESCRIPTION
## Summary

Register DeepSeek through SiteAdapter and SiteRegistry with conservative message, composer and theme selectors. Add URL and DOM regression coverage. No API integration or required host-permission changes.

## Related issue and authorization

Closes #960

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 1 of 11. Base: main. Head: codex/ds-stack-01-adapter.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/features/plugins/sites/adapters/deepseek.test.ts
src/features/plugins/sites/adapters/deepseek.ts
src/features/plugins/sites/registry.test.ts
src/features/plugins/sites/registry.ts
src/features/plugins/types.ts

## Verification

Published layer head: 44de83a3ad08333dda58220a1eb090964dd0e25c.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DeepSeek at chat.deepseek.com.
  - DeepSeek conversations now support chat interactions, composer detection, turn recognition, and light/dark theme detection.

- **Bug Fixes**
  - Restricted DeepSeek support to valid secure chat.deepseek.com URLs, excluding unrelated domains and look-alike addresses.

- **Tests**
  - Added coverage for DeepSeek conversation turns, composer selection, theme detection, and URL matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->