### PR TITLE
fix(plugins): display DeepSeek branding in the plugin manager

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -69,14 +69,15 @@ export function platformBadge(
   const brand = plugin.theme?.brand;
   const current = currentSiteId ? SITE_BADGES[currentSiteId] : undefined;
   if (current) return { icon: <current.Icon />, color: brand ?? current.color };
-  const host = plugin.matches
-    .map((m) => m.replace(/^[a-z*]+:\/\//i, '').replace(/\/.*$/, ''))
-    .join(' ');
-  if (host.includes('claude.ai'))
+  const hosts = plugin.matches.flatMap((pattern) => {
+    const match = /^(?:https?|\*):\/\/([^/]+)\//i.exec(pattern);
+    return match ? [match[1]] : [];
+  });
+  if (hosts.includes('claude.ai'))
     return { icon: <IconClaude />, color: brand ?? SITE_BADGES.claude.color };
-  if (host.includes('chatgpt.com') || host.includes('openai.com'))
+  if (hosts.includes('chatgpt.com') || hosts.includes('chat.openai.com'))
     return { icon: <IconChatGPT />, color: brand ?? SITE_BADGES.chatgpt.color };
-  if (plugin.matches.some((pattern) => pattern.startsWith('https://chat.deepseek.com/')))
+  if (hosts.includes('chat.deepseek.com'))
     return { icon: <IconDeepSeek />, color: brand ?? SITE_BADGES.deepseek.color };
   return null;
 }

--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -23,7 +23,7 @@ import type { PluginManifest, PluginSettingValue, SettingField } from '@/feature
 import { Card, CardContent, CardTitle } from '../../../components/ui/card';
 import { Switch } from '../../../components/ui/switch';
 import { useLanguage } from '../../../contexts/LanguageContext';
-import { IconChatGPT, IconClaude } from './WebsiteLogos';
+import { IconChatGPT, IconClaude, IconDeepSeek } from './WebsiteLogos';
 
 type EnabledMap = Record<string, boolean>;
 type SettingsMap = Record<string, Record<string, PluginSettingValue>>;
@@ -52,6 +52,7 @@ async function requestPluginContentScriptSync(): Promise<boolean> {
 const SITE_BADGES: Record<string, { Icon: typeof IconClaude; color: string }> = {
   claude: { Icon: IconClaude, color: '#d97757' },
   chatgpt: { Icon: IconChatGPT, color: '#0ea5e9' },
+  deepseek: { Icon: IconDeepSeek, color: '#4d6bfe' },
 };
 
 /**
@@ -75,6 +76,8 @@ export function platformBadge(
     return { icon: <IconClaude />, color: brand ?? SITE_BADGES.claude.color };
   if (host.includes('chatgpt.com') || host.includes('openai.com'))
     return { icon: <IconChatGPT />, color: brand ?? SITE_BADGES.chatgpt.color };
+  if (plugin.matches.some((pattern) => pattern.startsWith('https://chat.deepseek.com/')))
+    return { icon: <IconDeepSeek />, color: brand ?? SITE_BADGES.deepseek.color };
   return null;
 }
 

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PluginManifest } from '@/features/plugins/types';
 
 import { PluginManager, platformBadge } from '../PluginManager';
+import { IconDeepSeek } from '../WebsiteLogos';
 
 // The slider-debounce behaviour under test lives in PluginManager; the storage
 // layer is mocked so we can assert exactly how often (and with what value) the
@@ -433,6 +434,37 @@ describe('platformBadge', () => {
     expect(platformBadge(formulaCopy, 'chatgpt')?.color).toBe('#0ea5e9');
     expect(platformBadge(formulaCopy, 'claude')?.color).toBe('#d97757');
   });
+
+  it('uses the bundled DeepSeek icon and accent for the active platform', () => {
+    const plugin = {
+      ...formulaCopy,
+      matches: [...formulaCopy.matches, 'https://chat.deepseek.com/*'],
+    };
+    const badge = platformBadge(plugin, 'deepseek');
+    expect(badge?.color).toBe('#4d6bfe');
+    expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
+  });
+
+  it('recognizes a DeepSeek-only plugin before a site adapter is available', () => {
+    const badge = platformBadge({ ...formulaCopy, matches: ['https://chat.deepseek.com/*'] });
+    expect(badge?.color).toBe('#4d6bfe');
+    expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
+  });
+
+  it('preserves a DeepSeek plugin custom accent', () => {
+    const plugin = {
+      ...formulaCopy,
+      matches: ['https://chat.deepseek.com/*'],
+      theme: { brand: '#123456' },
+    };
+    expect(platformBadge(plugin)?.color).toBe('#123456');
+    expect(platformBadge(plugin, 'deepseek')?.color).toBe('#123456');
+  });
+
+  it.each(['https://chat.deepseek.com.example.org/*', 'https://example.org/chat.deepseek.com/*'])(
+    'does not mislabel unrelated matches %s as DeepSeek',
+    (pattern) => expect(platformBadge({ ...formulaCopy, matches: [pattern] })).toBeNull(),
+  );
 
   it('prefers the plugin-declared theme.brand over the site default', () => {
     const themed = { ...formulaCopy, theme: { brand: '#123456' } };

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -467,8 +467,31 @@ describe('platformBadge', () => {
   );
 
   it('prefers the plugin-declared theme.brand over the site default', () => {
+    // Existing platforms retain their own fallback colour.
     const themed = { ...formulaCopy, theme: { brand: '#123456' } };
     expect(platformBadge(themed, 'chatgpt')?.color).toBe('#123456');
+  });
+
+  it.each([
+    'https://notclaude.ai/*',
+    'https://claude.ai.example.org/*',
+    'https://notchatgpt.com/*',
+    'https://chat.openai.com.example.org/*',
+    'https://api.openai.com/*',
+    'https://example.org/claude.ai/*',
+  ])('does not infer an official chat platform from %s', (pattern) => {
+    expect(platformBadge({ ...formulaCopy, matches: [pattern] })).toBeNull();
+  });
+
+  it.each([
+    ['https://claude.ai/*', '#d97757'],
+    ['https://chatgpt.com/*', '#0ea5e9'],
+    ['https://chat.openai.com/*', '#0ea5e9'],
+    ['*://chatgpt.com/*', '#0ea5e9'],
+    ['http://chat.deepseek.com/*', '#4d6bfe'],
+    ['*://chat.deepseek.com/*', '#4d6bfe'],
+  ])('recognizes the exact chat host in %s', (pattern, color) => {
+    expect(platformBadge({ ...formulaCopy, matches: [pattern] })?.color).toBe(color);
   });
 
   it('falls back to the first matched host when the current site is unknown', () => {


### PR DESCRIPTION
## Summary

Use the existing DeepSeek icon and accent. Resolve platform badges using exact chat-host matching with positive and negative regression tests.

## Related issue and authorization

Refs #964

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 3 of 11. Base: codex/ds-stack-02-reading-width. Head: codex/ds-stack-03-platform-badge.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/pages/popup/components/PluginManager.tsx
src/pages/popup/components/__tests__/PluginManager.test.tsx

## Verification

Published layer head: 1ed7250054e7fc61f94f6fa7e6f0b362bb091f49.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DeepSeek platform badges for plugins associated with chat.deepseek.com.
  - Improved platform recognition for ChatGPT, Claude, OpenAI, and DeepSeek URLs.
  - Preserved custom plugin accent colors when displaying platform badges.

- **Bug Fixes**
  - Prevented unrelated or deceptive hostnames from receiving incorrect platform badges.

- **Tests**
  - Added coverage for exact host matching and platform badge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->