### PR TITLE
fix(plugins): retain accessible platform and setting context

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -496,6 +496,7 @@ export function PluginManager({
                     onClick={() => toggleCollapsed(plugin.id)}
                     className="group flex w-full items-start gap-1.5 text-left"
                     aria-expanded={isOpen}
+                    aria-label={localizedName}
                   >
                     <svg
                       width="11"
@@ -563,7 +564,7 @@ export function PluginManager({
                       companion-frame grant must not disable settings that still affect the
                       already-authorized parent page. */}
                   {enabled && settingsSchema && (
-                    <div className="mt-2 space-y-2.5">
+                    <div className="mt-2 space-y-2.5" role="group" aria-label={localizedName}>
                       {Object.entries(settingsSchema).map(([key, field]) => {
                         const rawValue = settingsMap[plugin.id]?.[key] ?? field.default;
                         const settingText = pickLocalizedSetting(plugin, key, field, language);

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -245,6 +245,47 @@ describe('PluginManager boolean setting', () => {
   });
 });
 
+describe('PluginManager accessible plugin identity', () => {
+  it('keeps the complete localized platform name on collapsed headers', async () => {
+    mockLanguage.current = 'zh';
+    const plugin: PluginManifest = {
+      ...widthPlugin,
+      name: 'Claude · Reading width',
+      i18n: { zh: { name: 'Claude · 阅读宽度' } },
+    };
+    await render(plugin);
+    const header = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    expect(header?.getAttribute('aria-label')).toBe('Claude · 阅读宽度');
+    expect(header?.getAttribute('aria-expanded')).toBe('true');
+    act(() => header?.click());
+    expect(header?.getAttribute('aria-expanded')).toBe('false');
+    expect(header?.getAttribute('aria-label')).toBe('Claude · 阅读宽度');
+  });
+
+  it('groups identically named controls under their owning plugins', async () => {
+    const second: PluginManifest = {
+      ...widthPlugin,
+      id: 'voyager.second-width',
+      name: 'ChatGPT · Width',
+      matches: ['https://chatgpt.com/*'],
+    };
+    pluginState.current[second.id] = { enabled: true, installedAt: 0 };
+    await act(async () => {
+      root.render(React.createElement(PluginManager, { manifests: [widthPlugin, second] }));
+    });
+    const groups = Array.from(container.querySelectorAll('[role="group"]'));
+    expect(groups.map((group) => group.getAttribute('aria-label'))).toEqual([
+      'Test · Width',
+      'ChatGPT · Width',
+    ]);
+    for (const group of groups) {
+      expect(group.querySelector('input[type="range"]')?.getAttribute('aria-label')).toBe(
+        'Reading width (px)',
+      );
+    }
+  });
+});
+
 describe('PluginManager host permission flow', () => {
   beforeEach(() => {
     pluginState.current = { [PLUGIN_ID]: { enabled: false, installedAt: 0 } };


### PR DESCRIPTION
## Summary

Preserve full localized names on plugin headers and associate repeated settings controls with their owning plugin. Include accessible-context regression tests.

## Related issue and authorization

Closes #965

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 4 of 11. Base: codex/ds-stack-03-platform-badge. Head: codex/ds-stack-04-accessibility.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/pages/popup/components/PluginManager.tsx
src/pages/popup/components/__tests__/PluginManager.test.tsx

## Verification

Published layer head: 9e0bbbb85282cfbae8bb4b3c160a54f8b7347d8f.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen reader support in the plugin catalog by labeling expandable headers and settings groups with each plugin’s localized name.
  - Ensured plugin names remain clearly identified in both collapsed and expanded views.
  - Grouped identical controls under distinct, plugin-labeled accessibility groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->