### PR TITLE
test(theme): cover DeepSeek platform branding

### DIFF
--- a/src/pages/content/platformTheme/__tests__/platformTheme.test.ts
+++ b/src/pages/content/platformTheme/__tests__/platformTheme.test.ts
@@ -37,10 +37,11 @@ const themedPlugin = (brand: string, matches: string[]): PluginManifest => ({
 });
 
 describe('resolveBrandColor', () => {
-  it('uses the adapter brandColor for Claude and ChatGPT', () => {
+  it('uses the adapter brandColor for Claude, ChatGPT and DeepSeek', () => {
     expect(resolveBrandColor('https://claude.ai/chat/1')).toBe('#d97757');
     expect(resolveBrandColor('https://chatgpt.com/c/1')).toBe('#0ea5e9');
     expect(resolveBrandColor('https://chat.openai.com/')).toBe('#0ea5e9');
+    expect(resolveBrandColor('https://chat.deepseek.com/a/chat/s/1')).toBe('#4d6bfe');
   });
 
   it('returns null for Gemini / AI Studio / unknown sites', () => {
@@ -83,6 +84,10 @@ describe('effectiveAccentForDisplay', () => {
     expect(effectiveAccentForDisplay('https://gemini.google.com/app')).toBe(DEFAULT_ACCENT);
   });
 
+  it('returns the DeepSeek adapter colour for a plugin-platform page', () => {
+    expect(effectiveAccentForDisplay('https://chat.deepseek.com/a/chat/s/1')).toBe('#4d6bfe');
+  });
+
   it('returns the adapter colour for Claude and the override when set', () => {
     expect(effectiveAccentForDisplay('https://claude.ai/x')).toBe('#d97757');
     expect(effectiveAccentForDisplay('https://claude.ai/x', [], { claude: '#0f0f0f' })).toBe(
@@ -121,6 +126,13 @@ describe('applyBrandTheme', () => {
     applyBrandTheme('https://claude.ai/x', [], document);
     expect(document.documentElement.classList.contains(PLATFORM_THEME_CLASS)).toBe(true);
     expect(document.documentElement.style.getPropertyValue('--gv-pm-brand')).toBe('#d97757');
+  });
+
+  it('applies the DeepSeek adapter colour to the Voyager UI root', () => {
+    applyBrandTheme('https://chat.deepseek.com/a/chat/s/1', [], document);
+    expect(document.documentElement.classList.contains(PLATFORM_THEME_CLASS)).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--gv-pm-brand')).toBe('#4d6bfe');
+    expect(document.documentElement.style.getPropertyValue('--gv-pm-brand-fg')).toBe('#ffffff');
   });
 
   it('adds nothing on Gemini', () => {


### PR DESCRIPTION
## Summary

Add regression coverage for the existing DeepSeek adapter accent in platform-theme styling. This layer changes tests only, not runtime theme behavior.

## Related issue and authorization

Refs #960

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 5 of 11. Base: codex/ds-stack-04-accessibility. Head: codex/ds-stack-05-platform-theme.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/pages/content/platformTheme/__tests__/platformTheme.test.ts

## Verification

Published layer head: 3321092566645d6cdf4e0c7500836bc06496a2f6.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify DeepSeek branding, including its accent color and themed display styling.
  * Added assertions confirming the correct brand colors and themed class are applied for DeepSeek chat URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->