### PR TITLE
fix(plugins): normalize DeepSeek plugin names

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -84,7 +84,7 @@ export function platformBadge(
 
 /** Strip a redundant "Claude · " / "ChatGPT · " platform prefix (the logo shows it). */
 function displayName(name: string): string {
-  return name.replace(/^(Claude|ChatGPT|Gemini|AI Studio)\s*[·:|]\s*/i, '');
+  return name.replace(/^(Claude|ChatGPT|Gemini|AI Studio|DeepSeek)\s*[·:|]\s*/i, '');
 }
 
 /**

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -540,3 +540,17 @@ describe('platformBadge', () => {
     expect(platformBadge(formulaCopy, undefined)?.color).toBe('#d97757');
   });
 });
+
+describe('PluginManager platform name display', () => {
+  it('removes the DeepSeek prefix when the platform badge is shown', async () => {
+    const plugin: PluginManifest = {
+      ...widthPlugin,
+      name: 'DeepSeek · Comfortable Reading Width',
+      matches: ['https://chat.deepseek.com/*'],
+    };
+    await render(plugin);
+    const header = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    expect(header?.textContent).toContain('Comfortable Reading Width');
+    expect(header?.textContent).not.toContain('DeepSeek ·');
+  });
+});


### PR DESCRIPTION
## Summary

Remove redundant DeepSeek platform prefixes from visible plugin names while retaining localized identity. Include display-name regression coverage.

## Related issue and authorization

Refs #964

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 6 of 11. Base: codex/ds-stack-05-platform-theme. Head: codex/ds-stack-06-plugin-naming.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/pages/popup/components/PluginManager.tsx
src/pages/popup/components/__tests__/PluginManager.test.tsx

## Verification

Published layer head: 9d33d7c6ff429fa1ed5c2e0e6d19d8e674db33b8.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin names beginning with the “DeepSeek ·” prefix now display without the redundant platform prefix when shown with a platform badge.

- **Tests**
  - Added coverage to verify correct rendering of DeepSeek plugin names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->