### PR TITLE
fix(plugins): scope platform badges to the active site

### DIFF
--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/core/utils/browser';
 import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
 import { pluginToOriginPatternsForActiveUrl } from '@/features/plugins/runtime/siteRegistration';
+import { matchesAnyPattern } from '@/features/plugins/sites/matchPattern';
 import { SiteRegistry } from '@/features/plugins/sites/registry';
 import {
   loadCollapsedPlugins,
@@ -65,8 +66,10 @@ const SITE_BADGES: Record<string, { Icon: typeof IconClaude; color: string }> = 
 export function platformBadge(
   plugin: PluginManifest,
   currentSiteId?: string,
+  activeUrl?: string,
 ): { icon: ReactNode; color: string } | null {
   const brand = plugin.theme?.brand;
+  if (activeUrl && !matchesAnyPattern(activeUrl, plugin.matches)) return null;
   const current = currentSiteId ? SITE_BADGES[currentSiteId] : undefined;
   if (current) return { icon: <current.Icon />, color: brand ?? current.color };
   const hosts = plugin.matches.flatMap((pattern) => {
@@ -483,7 +486,7 @@ export function PluginManager({
           const isOpen = !collapsed.has(plugin.id);
           const hosts = siteHostsFromMatches(plugin.matches);
           const settingsSchema = plugin.contributes.settings;
-          const badge = platformBadge(plugin, currentSiteId);
+          const badge = platformBadge(plugin, currentSiteId, activeUrl);
           const localizedName = pickLocalized(plugin, 'name', language);
           const needsSiteAccess = enabled && missingPermissionIds.has(plugin.id);
           return (

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -486,6 +486,15 @@ describe('platformBadge', () => {
     expect(React.isValidElement(badge?.icon) && badge.icon.type).toBe(IconDeepSeek);
   });
 
+  it('does not use the active DeepSeek badge for a plugin that excludes DeepSeek', () => {
+    const badge = platformBadge(
+      { ...formulaCopy, matches: ['https://claude.ai/*'] },
+      'deepseek',
+      'https://chat.deepseek.com/a/chat/s/current',
+    );
+    expect(badge).toBeNull();
+  });
+
   it('recognizes a DeepSeek-only plugin before a site adapter is available', () => {
     const badge = platformBadge({ ...formulaCopy, matches: ['https://chat.deepseek.com/*'] });
     expect(badge?.color).toBe('#4d6bfe');


### PR DESCRIPTION
## Summary

Require the plugin to match the active URL before resolving its current-site badge. Include a regression for a nonmatching plugin on DeepSeek.

## Related issue and authorization

Closes #964

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 7 of 11. Base: codex/ds-stack-06-plugin-naming. Head: codex/ds-stack-07-badge-scope.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/pages/popup/components/PluginManager.tsx
src/pages/popup/components/__tests__/PluginManager.test.tsx

## Verification

Published layer head: 103626cf778c649c65ac3baef667b5cb1f491f00.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin badges are now hidden when the active website does not match the plugin’s supported site patterns.
  - Prevents incorrect platform badges from appearing on unsupported pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->