### PR TITLE
docs(plugins): explain new platform contribution layers

### DIFF
--- a/docs/en/guide/plugin-contribution.md
+++ b/docs/en/guide/plugin-contribution.md
@@ -12,6 +12,31 @@ This keeps plugins easier to review and maintain. If you want to contribute a pl
 4. Put styles in `style.css` in the same plugin directory, then reference it from `contributes.styles`.
 5. Test locally and include test pages, screenshots, or a short recording in the PR. Maintainers will decide whether it is ready for the official catalog.
 
+## Adding a new platform
+
+Adding a new chat website has two separate layers:
+
+1. The **site adapter** teaches Voyager how to recognize the website and find
+   its user turns, assistant turns, composer, sidebar, and theme markers.
+2. A **plugin** solves one user-facing problem on that website, such as reading
+   width or a rendering fix.
+
+For a new platform such as DeepSeek, keep the adapter work focused on the
+platform contract. Put the adapter, registry entry, required selector tests,
+and the minimum documentation needed to explain the support in one complete
+change. Do not add a new adapter for every plugin.
+
+After the adapter is accepted, follow-up plugins can be submitted as separate
+focused changes. If several changes depend on one another, a stacked PR chain
+is useful: each later branch is based on the previous branch, and each PR
+shows only its own incremental feature. The chain should still follow the same
+scope rule: one clear user goal per PR, with its required tests and cleanup.
+
+Site support does not require a model API integration. Do not add static
+content scripts or required host permissions for a new platform; use the
+existing optional-permission and dynamic-registration flow for plugin-only
+sites.
+
 ## Plugin scope
 
 Plugins should be scoped by the user problem they solve, not mechanically split by platform.


### PR DESCRIPTION
## Summary

Document the distinction between a site adapter and user-facing plugins, the optional-permission path, and focused contribution layers. English contribution-guide change only; other locale guide translations are not included.

## Related issue and authorization

Closes #966

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 8 of 11. Base: codex/ds-stack-07-badge-scope. Head: codex/ds-stack-08-contribution-docs.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

docs/en/guide/plugin-contribution.md

## Verification

Published layer head: b83997575f1c19ad76d7540d9f8659086f89a26c.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for contributing support for new platforms.
  - Clarified the distinction between platform adapters and user-facing plugins.
  - Documented recommended contribution structure, including focused follow-up changes and selector tests.
  - Clarified that platform support does not require model API integration or static content scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->