### PR TITLE
docs(plugins): document DeepSeek bundled catalog support

### DIFF
--- a/src/features/plugins/README.md
+++ b/src/features/plugins/README.md
@@ -2,7 +2,7 @@
 
 A self-contained subsystem that lets Voyager run **plugins** — units that inject
 styles / DOM changes into AI chat sites (Gemini, AI Studio, ChatGPT, Claude,
-…). Voyager's own features can migrate onto this over time; third parties
+DeepSeek, …). Voyager's own features can migrate onto this over time; third parties
 can ship their own plugins against the same contract.
 
 ## Two design constraints that shaped everything
@@ -106,9 +106,9 @@ prefixed (content-script rule).
 
 ## What is NOT done yet (next milestones)
 
-- **Full setting UI coverage.** The schema accepts boolean/string/color/select,
-  but the popup currently renders the number/range control used by the official
-  width plugins.
+- **Full setting UI coverage.** The schema accepts boolean/string/color/select;
+  the popup currently renders boolean switches and number/range controls, while
+  string, color and select controls remain future work.
 - **Scripted runtime** via gated `chrome.userScripts`.
 - **Account + Stripe entitlement**.
 

--- a/src/features/plugins/catalog/marketplace.json
+++ b/src/features/plugins/catalog/marketplace.json
@@ -6,7 +6,7 @@
     "name": "voyager-official",
     "url": "https://github.com/Nagi-ovo/voyager"
   },
-  "description": "Bundled official plugin catalog for Voyager — declarative plugins that enhance AI chat sites (Claude, ChatGPT, …).",
+  "description": "Bundled official plugin catalog for Voyager — declarative plugins that enhance AI chat sites (Claude, ChatGPT, DeepSeek, …).",
   "plugins": [
     {
       "name": "claude-cjk-render-fix",


### PR DESCRIPTION
## Summary

Update the plugin architecture README and bundled-catalog description to include DeepSeek and current settings support. This layer changes documentation and descriptive catalog metadata only.

## Related issue and authorization

Refs #960; refs #966

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 9 of 11. Base: codex/ds-stack-08-contribution-docs. Head: codex/ds-stack-09-catalog-docs.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/features/plugins/README.md
src/features/plugins/catalog/marketplace.json

## Verification

Published layer head: 64fc17ca4e181d4044fdd0eb61183f0a02841f7d.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DeepSeek to the list of supported AI chat sites in the plugin documentation and marketplace catalog.
  * Clarified the status of plugin setting controls: boolean and number/range controls are implemented, while string, color, and select controls remain unfinished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->