### PR TITLE
test(plugins): guard DeepSeek permission scope

### DIFF
--- a/src/features/plugins/runtime/siteRegistration.test.ts
+++ b/src/features/plugins/runtime/siteRegistration.test.ts
@@ -47,6 +47,7 @@ describe('pluginsToOriginPatterns', () => {
 
 describe('pluginToOriginPatternsForActiveUrl', () => {
   const chatgptPlugin = mk(['https://chatgpt.com/*', 'https://chat.openai.com/*']);
+  const deepseekPlugin = mk(['https://chat.deepseek.com/*', 'https://chat.deepseek.com/a/chat/*']);
   const claudeArtifactPlugin = mk([
     'https://claude.ai/*',
     'https://*.frame.claudeusercontent.com/*',
@@ -74,6 +75,21 @@ describe('pluginToOriginPatternsForActiveUrl', () => {
         'https://claude.ai/code/artifact/example',
       ),
     ).toEqual(['https://*.frame.claudeusercontent.com/*', 'https://claude.ai/*']);
+  });
+
+  it('requests only the DeepSeek chat origin from a DeepSeek page', () => {
+    expect(
+      pluginToOriginPatternsForActiveUrl(
+        deepseekPlugin,
+        'https://chat.deepseek.com/a/chat/s/current',
+      ),
+    ).toEqual(['https://chat.deepseek.com/*']);
+  });
+
+  it('does not expand DeepSeek permission scope for an unrelated active page', () => {
+    expect(pluginToOriginPatternsForActiveUrl(deepseekPlugin, 'https://example.com/')).toEqual([
+      'https://chat.deepseek.com/*',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Add regression coverage ensuring DeepSeek activation derives only its chat origin and does not widen unrelated-page permissions. Test-only layer.

## Related issue and authorization

Refs #967

The contributor reports direct maintainer approval for the DeepSeek contribution and a stacked review workflow. This migration was requested after upstream write access was granted. No private conversation or credentials are included.

## Stack position

Layer 10 of 11. Base: codex/ds-stack-09-catalog-docs. Head: codex/ds-stack-10-permission-origin.
This is an incremental review sequence, not a claim that every layer has a runtime dependency on the preceding layer. Review only this layer's diff; do not merge an upper PR independently into an intermediate branch.

This upstream-only stack replaces the earlier fork-based proposals #962, #963 and #968. Those PRs remain open and untouched pending maintainer cleanup; do not merge both versions.

## Changed files

src/features/plugins/runtime/siteRegistration.test.ts

## Verification

Published layer head: df3b457a0036fbe89dde4a7901cb1e608db3540a.
Combined stack tested at 4ad3ec811f3496f1eb36f46815f6341e893190bb on 2026-09-07:
- bun run test -- src/features/plugins src/pages/popup src/pages/content/platformTheme --maxWorkers=1 --silent: 49 files / 482 tests passed.
- bun run typecheck: passed.
- bun run format:check: passed.
- bun run lint:check: passed with existing repository warnings.
- bun run docs:build: passed.
- bun run build:chrome: passed (build only, not browser-runtime acceptance).
- git diff --check: passed for this layer.

These are combined-stack results, not a claim that the complete suite was rerun at every intermediate head. The current GitHub checks provide additional per-PR evidence. No source-code edits or new commits were introduced by this publishing migration.

## Pending checks and ownership

- Marked ready for review on 2026-09-07 at the maintainer's request. Ready for review does not mean merge-ready; the following acceptance gaps remain open. Contributor ccch1mneyyy owns manual extension loading, permission accept/deny, enable/disable/reload, streaming, light/dark, narrow/desktop and redacted visual proof for the runtime/UI layers. ARIA tests do not replace assistive-technology testing.
- Full verify:pr was not rerun during this migration. Earlier full-suite runs recorded Windows release-privacy failures and an intermittent Mermaid timeout; those historical results do not establish current full-suite success.
- Firefox/Safari/Edge runtime checks remain unverified; a tester with those browsers, including macOS for Safari, must be assigned with the maintainer.
- For test-only and prose-only layers, there is no new runtime behavior to demonstrate separately, but shared feature acceptance remains pending.
- Mutating format/lint commands were not rerun because this migration preserves existing commits; read-only checks were used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for DeepSeek chat pages to verify that site permissions are limited to the relevant DeepSeek origin.
  - Added coverage confirming that unrelated active pages do not expand the requested permission scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->