### PR TITLE
docs(plugins): clarify browser support for dynamic registration

### DIFF
--- a/docs/en/guide/plugin-contribution.md
+++ b/docs/en/guide/plugin-contribution.md
@@ -37,6 +37,15 @@ content scripts or required host permissions for a new platform; use the
 existing optional-permission and dynamic-registration flow for plugin-only
 sites.
 
+The optional-permission and dynamic-registration path is browser-version
+dependent. Chrome and Edge support the flow used by the extension. Firefox
+requires version 128 or newer for optional host permissions, and Safari
+requires version 16.4 or newer for dynamic content-script registration. On
+older supported browser versions, the popup may correctly refuse to enable a
+plugin for a custom site because the required APIs cannot provide a persistent
+grant; do not work around this by adding a broad static host permission without
+maintainer approval.
+
 ## Plugin scope
 
 Plugins should be scoped by the user problem they solve, not mechanically split by platform.


### PR DESCRIPTION
## Summary

Clarify the browser-version limits of Voyager's optional host permission and dynamic content-script registration path for new plugin platforms.

The guide now documents Firefox 128+ for optional host permissions and Safari 16.4+ for dynamic content-script registration. It also explains that older supported versions may refuse to enable a custom-site plugin instead of justifying a broad static host permission.

## Related issue

Refs #966. This follow-up addresses the compatibility note raised during review of the merged DeepSeek contribution stack.

## Verification

- `bun run format:check` passed.
- `bun run docs:build` passed.
- `git diff --check` passed.
- Browser testing is not applicable to this documentation-only change.

No runtime code, permissions, manifests, or generated artifacts were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added browser compatibility guidance for optional permissions and dynamic content-script registration.
  - Documented support details for Chrome, Edge, Firefox 128+, and Safari 16.4+.
  - Clarified that plugin enablement may fail on older browser versions.
  - Documented approval requirements for broad static host permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->