### PR TITLE
fix(turn-navigator): order stitched turns by position and make compact ticks usable

### DIFF
--- a/.github/docs/regressions/folders-timeline-ui.md
+++ b/.github/docs/regressions/folders-timeline-ui.md
@@ -220,7 +220,8 @@ drop, or hover layout.
 - **Rule:** Keep a grow-only registry stitched across overlapping windows by content hash:
   `c-<textHash>`, with `~n` for duplicates and hash-segment matching for legacy stars. Navigate to
   unmounted turns iteratively with instant probing and direction-aware bisection, then fine-aim
-  after mount. Every jump is instant: smooth scrolling drifts while Claude re-measures, and mixing
+  after mount. Every jump passes `behavior: 'instant'` (`'auto'` follows the page's CSS
+  `scroll-behavior`, so it can still animate): smooth scrolling drifts while Claude re-measures, and mixing
   smooth short hops with instant long ones reads as erratic. Reuse this virtual-window model for
   future Claude DOM features.
 - **Guard:** `src/features/plugins/builtin/claudeTimeline/index.test.ts` covers sparse-window

--- a/.github/docs/regressions/folders-timeline-ui.md
+++ b/.github/docs/regressions/folders-timeline-ui.md
@@ -219,11 +219,38 @@ drop, or hover layout.
   Remembered absolute offsets also drift while Claude remeasures newly mounted content.
 - **Rule:** Keep a grow-only registry stitched across overlapping windows by content hash:
   `c-<textHash>`, with `~n` for duplicates and hash-segment matching for legacy stars. Navigate to
-  unmounted turns iteratively with instant probing and direction-aware bisection, then smooth
-  fine-aim after mount. Make jumps over three viewports instant. Reuse this virtual-window model for
+  unmounted turns iteratively with instant probing and direction-aware bisection, then fine-aim
+  after mount. Every jump is instant: smooth scrolling drifts while Claude re-measures, and mixing
+  smooth short hops with instant long ones reads as erratic. Reuse this virtual-window model for
   future Claude DOM features.
 - **Guard:** `src/features/plugins/builtin/claudeTimeline/index.test.ts` covers sparse-window
   stability, durable IDs, and marker retention during virtualization.
+
+## Turn navigator blocks are filed by scroll position between anchors
+
+- **Trap:** Claude now mounts about four turns plus the latest turn, which stays mounted while the
+  reader sits at the top. Stitching a freshly mounted block "right before its first anchor" filed the
+  conversation's opening turns behind the bottom window, so the preview list, the rail order and
+  the active marker were all wrong after one scroll to the top.
+- **Rule:** Anchors (hash matches) fix the relative order; a block of unknown turns is inserted by
+  its scroll position among the known turns between its two bounding anchors, comparing known
+  centres after the nearest anchor's re-measure drift. Never assume a mounted window is contiguous.
+- **Guard:** `src/features/plugins/builtin/claudeTimeline/index.test.ts`
+  (`keeps the opening turns ahead of the bottom window when Claude leaves the latest turn mounted`,
+  `files a bottom window behind the known opening turns when the first turn stays mounted`).
+
+## Compact turn-navigator ticks spread over the track and stay clickable
+
+- **Trap:** Compact ticks were squeezed into a fixed 240px cluster, so a long conversation rendered
+  as an unreadable barcode on a 1100px track, and `pointer-events: none` on the ticks meant a click
+  only toggled the preview panel instead of jumping.
+- **Rule:** Keep a fixed tick pitch and let the cluster use the whole track (minus end padding);
+  shrink the pitch only when the conversation outgrows the track, and re-space on resize. On
+  `[data-gv-turn-navigator]` rails a tick click navigates (stop propagation so the rail's panel
+  toggle does not fire) while hover still opens the preview; compact ticks show no tooltip.
+- **Guard:** `src/features/plugins/builtin/claudeTimeline/index.test.ts`
+  (`spreads compact ticks over the whole track instead of a fixed cluster`,
+  `jumps from a compact tick without toggling the preview panel or a tooltip`).
 
 ## The chat width sparkle rule also matches the Gemini logo pill
 

--- a/.github/docs/regressions/providers-plugins.md
+++ b/.github/docs/regressions/providers-plugins.md
@@ -277,3 +277,17 @@ while an active plugin has domOps`).
 - **Guard:** `src/features/plugins/sites/safeRegex.test.ts`,
   `src/features/plugins/verbs/turnNavigator.test.ts`
   (`validates selectors, the id pattern and the rail side`).
+
+## Plugin content-script registration must unregister only registered ids
+
+- **Trap:** The plugin sync batched the plugin, embedded-frame and Claude-usage script ids into
+  one `unregisterContentScripts` call. Chrome rejects the whole call when any id is unknown, and
+  the following `registerContentScripts` then failed on the duplicate id, so the registration
+  froze on the first result of a session: enabling DeepSeek plugins after ChatGPT/Claude were
+  already registered changed nothing until the extension restarted, and the popup showed the
+  toggles on with no site injected.
+- **Rule:** Before unregistering, list the registered scripts and unregister only the ids that
+  exist (`src/pages/background/contentScriptRegistration.ts`). Never batch a possibly-absent
+  companion id into an unregister call.
+- **Guard:** `src/pages/background/__tests__/contentScriptRegistration.test.ts`
+  (`drops only the ids that exist so a never-registered companion cannot block the batch`).

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -576,6 +576,13 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
   pointer-events: none;
 }
 
+/* Turn-navigator rails (Claude, DeepSeek, ...): a compact tick jumps straight
+ * to its turn; hovering the rail still opens the preview panel. */
+.gemini-timeline-bar[data-gv-turn-navigator].timeline-style-compact .timeline-track,
+.gemini-timeline-bar[data-gv-turn-navigator].timeline-style-compact .timeline-dot {
+  pointer-events: auto;
+}
+
 .gemini-timeline-bar.timeline-style-compact .timeline-dot::before {
   display: none;
 }

--- a/src/features/plugins/builtin/claudeTimeline/index.test.ts
+++ b/src/features/plugins/builtin/claudeTimeline/index.test.ts
@@ -125,7 +125,7 @@ describe('Claude timeline', () => {
     expect(dots).toHaveLength(2);
 
     dots[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' });
     expect(dots[0].classList.contains('active')).toBe(true);
     expect(dots[0].getAttribute('aria-current')).toBe('true');
   });
@@ -233,7 +233,7 @@ describe('Claude timeline', () => {
     ).toBe(false);
 
     dot.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'instant' });
     expect(bar.getAttribute('aria-expanded')).toBe('false');
     expect(document.querySelector('.timeline-preview-panel')?.classList.contains('visible')).toBe(
       false,
@@ -316,7 +316,7 @@ describe('Claude timeline', () => {
     await flush();
 
     queryDots()[1].click();
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'instant' });
   });
 
   it('long-presses a dot to star it', async () => {
@@ -645,12 +645,12 @@ describe('Claude timeline', () => {
     // First hop jumps instantly to the remembered offset (center 720 → top 450).
     queryDots()[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'instant' });
 
     // Still unmounted after a hop interval: bisect further instead of giving up.
     vi.advanceTimersByTime(200);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 1030, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 1030, behavior: 'instant' });
 
     // Turn mounts: the next hop aims precisely and stops.
     document.body.appendChild(second);
@@ -658,7 +658,7 @@ describe('Claude timeline', () => {
     vi.advanceTimersByTime(200);
     await flush();
     expect(window.scrollTo).toHaveBeenCalledTimes(3);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'instant' });
 
     vi.advanceTimersByTime(600);
     expect(window.scrollTo).toHaveBeenCalledTimes(3);
@@ -685,18 +685,18 @@ describe('Claude timeline', () => {
     // Target sits between two mounted turns: probe its remembered offset...
     queryDots()[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'instant' });
 
     // ...then bisect between the mounted neighbours instead of giving up.
     vi.advanceTimersByTime(200);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 400, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 400, behavior: 'instant' });
 
     document.body.insertBefore(second, third);
     await flush();
     vi.advanceTimersByTime(200);
     await flush();
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'instant' });
   });
 
   it('jumps instantly for long-distance navigation to a mounted turn, then fine-aims', async () => {
@@ -712,12 +712,12 @@ describe('Claude timeline', () => {
     // Distance > 3 viewports: jump, then fine-aim once the region re-measures.
     queryDots()[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 4750, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 4750, behavior: 'instant' });
 
     // Next hop fine-aims and ends the navigation.
     vi.advanceTimersByTime(200);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 4750, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 4750, behavior: 'instant' });
 
     vi.advanceTimersByTime(600);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
@@ -753,7 +753,7 @@ describe('Claude timeline', () => {
     await flush();
 
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'instant' });
 
     addTurn('third prompt');
     await settleRefresh();

--- a/src/features/plugins/builtin/claudeTimeline/index.test.ts
+++ b/src/features/plugins/builtin/claudeTimeline/index.test.ts
@@ -558,6 +558,33 @@ describe('Claude timeline', () => {
     ]);
   });
 
+  it('places a new turn by the drift of its nearer anchor when the two anchors drifted differently', async () => {
+    const rect = (top: number) => vi.fn(() => ({ top, bottom: top + 40, height: 40 }) as DOMRect);
+    const a = addTurn('turn a');
+    const b = addTurn('turn b');
+    const c = addTurn('turn c');
+    const d = addTurn('turn d');
+    a.getBoundingClientRect = rect(1000);
+    b.getBoundingClientRect = rect(2000);
+    c.getBoundingClientRect = rect(3000);
+    d.getBoundingClientRect = rect(4000);
+    startClaudeTimeline();
+    await flush();
+
+    // b and c unmount; a stays where it was, d is re-measured 2000px lower, and
+    // a new turn x mounts between them at 2600. Under a's drift (0) x sits
+    // after b; only under d's drift would it land before b.
+    b.remove();
+    c.remove();
+    const x = createTurn('turn x');
+    x.getBoundingClientRect = rect(2600);
+    document.body.insertBefore(x, d);
+    d.getBoundingClientRect = rect(6000);
+    await settleRefresh();
+
+    expect(dotLabels()).toEqual(['turn a', 'turn b', 'turn x', 'turn c', 'turn d']);
+  });
+
   it('files a bottom window behind the known opening turns when the first turn stays mounted', async () => {
     const rect = (top: number) => vi.fn(() => ({ top, bottom: top + 40, height: 40 }) as DOMRect);
     const first = addTurn('first prompt');

--- a/src/features/plugins/builtin/claudeTimeline/index.test.ts
+++ b/src/features/plugins/builtin/claudeTimeline/index.test.ts
@@ -125,7 +125,7 @@ describe('Claude timeline', () => {
     expect(dots).toHaveLength(2);
 
     dots[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
     expect(dots[0].classList.contains('active')).toBe(true);
     expect(dots[0].getAttribute('aria-current')).toBe('true');
   });
@@ -199,6 +199,47 @@ describe('Claude timeline', () => {
     );
   });
 
+  it('spreads compact ticks over the whole track instead of a fixed cluster', async () => {
+    for (let index = 0; index < 60; index += 1) addTurn(`prompt ${index}`);
+    startClaudeTimeline({ compactView: true });
+    await flush();
+
+    const track = document.querySelector<HTMLElement>('.timeline-track')!;
+    Object.defineProperty(track, 'clientHeight', { configurable: true, value: 1000 });
+    window.dispatchEvent(new Event('resize'));
+
+    const offsets = queryDots().map((dot) =>
+      dot.style.getPropertyValue('--timeline-compact-offset'),
+    );
+    expect(offsets[0]).toBe('-295px');
+    expect(offsets[30]).toBe('5px');
+    expect(offsets[59]).toBe('295px');
+  });
+
+  it('jumps from a compact tick without toggling the preview panel or a tooltip', async () => {
+    addTurn('first prompt');
+    const second = addTurn('second prompt');
+    second.getBoundingClientRect = vi.fn(() => ({ top: 700, bottom: 740, height: 40 }) as DOMRect);
+    startClaudeTimeline({ compactView: true });
+    await flush();
+
+    const bar = document.querySelector<HTMLElement>('.gemini-timeline-bar')!;
+    expect(bar.getAttribute('aria-expanded')).toBe('false');
+    const dot = queryDots()[1];
+    dot.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    vi.advanceTimersByTime(1000);
+    expect(
+      document.getElementById('gv-turn-navigator-tooltip')?.classList.contains('visible'),
+    ).toBe(false);
+
+    dot.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
+    expect(bar.getAttribute('aria-expanded')).toBe('false');
+    expect(document.querySelector('.timeline-preview-panel')?.classList.contains('visible')).toBe(
+      false,
+    );
+  });
+
   it('updates active dot from the current viewport', async () => {
     const first = addTurn('first prompt');
     const second = addTurn('second prompt');
@@ -247,7 +288,7 @@ describe('Claude timeline', () => {
     expect(dots[1].classList.contains('active')).toBe(false);
   });
 
-  it('keeps clicked dot active while smooth scroll is settling', async () => {
+  it('keeps clicked dot active while the jump settles', async () => {
     const first = addTurn('first prompt');
     const second = addTurn('second prompt');
     first.getBoundingClientRect = vi.fn(() => ({ top: 0, bottom: 40, height: 40 }) as DOMRect);
@@ -275,7 +316,7 @@ describe('Claude timeline', () => {
     await flush();
 
     queryDots()[1].click();
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
   });
 
   it('long-presses a dot to star it', async () => {
@@ -482,6 +523,69 @@ describe('Claude timeline', () => {
     expect(dotLabels()).toEqual(['one', 'two', 'three', 'four', 'five']);
   });
 
+  it('keeps the opening turns ahead of the bottom window when Claude leaves the latest turn mounted', async () => {
+    const rect = (top: number) => vi.fn(() => ({ top, bottom: top + 40, height: 40 }) as DOMRect);
+    // Loaded at the bottom: only the last turns are mounted.
+    const lateOne = addTurn('late one');
+    const lateTwo = addTurn('late two');
+    const last = addTurn('last prompt');
+    lateOne.getBoundingClientRect = rect(38000);
+    lateTwo.getBoundingClientRect = rect(38500);
+    last.getBoundingClientRect = rect(39000);
+    startClaudeTimeline();
+    await flush();
+    expect(dotLabels()).toEqual(['late one', 'late two', 'last prompt']);
+
+    // Scrolled to the top: Claude mounts the opening turns, unmounts the late
+    // ones, but keeps the latest turn mounted (and re-measured further down).
+    lateOne.remove();
+    lateTwo.remove();
+    const first = createTurn('first prompt');
+    const second = createTurn('second prompt');
+    first.getBoundingClientRect = rect(100);
+    second.getBoundingClientRect = rect(1200);
+    document.body.insertBefore(second, last);
+    document.body.insertBefore(first, second);
+    last.getBoundingClientRect = rect(41600);
+    await settleRefresh();
+
+    expect(dotLabels()).toEqual([
+      'first prompt',
+      'second prompt',
+      'late one',
+      'late two',
+      'last prompt',
+    ]);
+  });
+
+  it('files a bottom window behind the known opening turns when the first turn stays mounted', async () => {
+    const rect = (top: number) => vi.fn(() => ({ top, bottom: top + 40, height: 40 }) as DOMRect);
+    const first = addTurn('first prompt');
+    const second = addTurn('second prompt');
+    const third = addTurn('third prompt');
+    first.getBoundingClientRect = rect(100);
+    second.getBoundingClientRect = rect(1200);
+    third.getBoundingClientRect = rect(2300);
+    startClaudeTimeline();
+    await flush();
+
+    second.remove();
+    third.remove();
+    const late = addTurn('late prompt');
+    const last = addTurn('last prompt');
+    late.getBoundingClientRect = rect(38000);
+    last.getBoundingClientRect = rect(39000);
+    await settleRefresh();
+
+    expect(dotLabels()).toEqual([
+      'first prompt',
+      'second prompt',
+      'third prompt',
+      'late prompt',
+      'last prompt',
+    ]);
+  });
+
   it('assigns distinct ids to turns with identical text', async () => {
     addTurn('same text');
     addTurn('same text');
@@ -527,7 +631,7 @@ describe('Claude timeline', () => {
     vi.advanceTimersByTime(200);
     await flush();
     expect(window.scrollTo).toHaveBeenCalledTimes(3);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'auto' });
 
     vi.advanceTimersByTime(600);
     expect(window.scrollTo).toHaveBeenCalledTimes(3);
@@ -565,7 +669,7 @@ describe('Claude timeline', () => {
     await flush();
     vi.advanceTimersByTime(200);
     await flush();
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 450, behavior: 'auto' });
   });
 
   it('jumps instantly for long-distance navigation to a mounted turn, then fine-aims', async () => {
@@ -578,15 +682,15 @@ describe('Claude timeline', () => {
     startClaudeTimeline();
     await flush();
 
-    // Distance > 3 viewports: instant jump instead of a long smooth scroll.
+    // Distance > 3 viewports: jump, then fine-aim once the region re-measures.
     queryDots()[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
     expect(window.scrollTo).toHaveBeenCalledWith({ top: 4750, behavior: 'auto' });
 
-    // Next hop fine-aims smoothly and ends the navigation.
+    // Next hop fine-aims and ends the navigation.
     vi.advanceTimersByTime(200);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
-    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 4750, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 4750, behavior: 'auto' });
 
     vi.advanceTimersByTime(600);
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
@@ -622,7 +726,7 @@ describe('Claude timeline', () => {
     await flush();
 
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
-    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'smooth' });
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 450, behavior: 'auto' });
 
     addTurn('third prompt');
     await settleRefresh();

--- a/src/features/plugins/catalog/sites/claude/plugins/reading-width/README.md
+++ b/src/features/plugins/catalog/sites/claude/plugins/reading-width/README.md
@@ -46,4 +46,6 @@ Voyager's bundled engine. No executable code.
 Claude now caps the turn column twice: `max-w-3xl` on the column and
 `max-w-[50.5rem]` (808px, the column plus its 20px side padding) on the wrapper
 above it. The plugin widens both; the wrapper rule matches structurally (the
-parent of the `max-w-3xl` column) so it survives the next class rename.
+parent of the `max-w-3xl` column), so a rename of the wrapper's own class does
+not break it. Both rules still key on `max-w-3xl`: if Claude renames that,
+the column is clamped again and the selector needs a follow-up.

--- a/src/features/plugins/catalog/sites/claude/plugins/reading-width/README.md
+++ b/src/features/plugins/catalog/sites/claude/plugins/reading-width/README.md
@@ -42,3 +42,8 @@ Voyager's engine. Push the slider right for a much wider column on big screens.
 
 This is a **declarative** plugin: pure CSS + a typed setting, interpreted by
 Voyager's bundled engine. No executable code.
+
+Claude now caps the turn column twice: `max-w-3xl` on the column and
+`max-w-[50.5rem]` (808px, the column plus its 20px side padding) on the wrapper
+above it. The plugin widens both; the wrapper rule matches structurally (the
+parent of the `max-w-3xl` column) so it survives the next class rename.

--- a/src/features/plugins/catalog/sites/claude/plugins/reading-width/plugin.json
+++ b/src/features/plugins/catalog/sites/claude/plugins/reading-width/plugin.json
@@ -2,8 +2,9 @@
   "$schema": "https://voyager.nagi.fun/plugin.schema.json",
   "id": "voyager.claude-reading-width",
   "name": "Claude · Comfortable Reading Width",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Widen Claude's conversation to one centered, adjustable column, with user and assistant messages aligned together.",
+  "changelog": "Follows Claude's new outer column cap (max-w-[50.5rem]) so the reading width applies again.",
   "i18n": {
     "zh": {
       "name": "Claude · 舒适阅读宽度",
@@ -14,7 +15,8 @@
           "minLabel": "更窄",
           "maxLabel": "更宽"
         }
-      }
+      },
+      "changelog": "跟进 Claude 新增的外层列宽上限（max-w-[50.5rem]），阅读宽度重新生效。"
     },
     "zh_TW": {
       "name": "Claude · 舒適閱讀寬度",
@@ -25,7 +27,8 @@
           "minLabel": "更窄",
           "maxLabel": "更寬"
         }
-      }
+      },
+      "changelog": "跟進 Claude 新增的外層欄寬上限（max-w-[50.5rem]），閱讀寬度重新生效。"
     },
     "ja": {
       "name": "Claude · 快適な読書幅",
@@ -36,7 +39,8 @@
           "minLabel": "狭く",
           "maxLabel": "広く"
         }
-      }
+      },
+      "changelog": "Claude が追加した外側の列幅上限（max-w-[50.5rem]）に追従し、読書幅が再び効くようにしました。"
     },
     "ko": {
       "name": "Claude · 편안한 읽기 너비",
@@ -47,7 +51,8 @@
           "minLabel": "좁게",
           "maxLabel": "넓게"
         }
-      }
+      },
+      "changelog": "Claude가 추가한 바깥쪽 열 너비 상한(max-w-[50.5rem])을 따라가 읽기 너비가 다시 적용됩니다."
     },
     "fr": {
       "name": "Claude · Largeur de lecture confortable",
@@ -58,7 +63,8 @@
           "minLabel": "Plus étroit",
           "maxLabel": "Plus large"
         }
-      }
+      },
+      "changelog": "Suit la nouvelle limite de largeur externe de Claude (max-w-[50.5rem]) pour que la largeur de lecture s'applique à nouveau."
     },
     "es": {
       "name": "Claude · Ancho de lectura cómodo",
@@ -69,7 +75,8 @@
           "minLabel": "Más estrecho",
           "maxLabel": "Más ancho"
         }
-      }
+      },
+      "changelog": "Sigue el nuevo límite de ancho exterior de Claude (max-w-[50.5rem]) para que el ancho de lectura vuelva a aplicarse."
     },
     "pt": {
       "name": "Claude · Largura de leitura confortável",
@@ -80,7 +87,8 @@
           "minLabel": "Mais estreito",
           "maxLabel": "Mais largo"
         }
-      }
+      },
+      "changelog": "Acompanha o novo limite de largura externo do Claude (max-w-[50.5rem]) para que a largura de leitura volte a valer."
     },
     "ru": {
       "name": "Claude · Удобная ширина чтения",
@@ -91,7 +99,8 @@
           "minLabel": "Уже",
           "maxLabel": "Шире"
         }
-      }
+      },
+      "changelog": "Учитывает новый внешний предел ширины колонки Claude (max-w-[50.5rem]), чтобы ширина чтения снова применялась."
     },
     "ar": {
       "name": "Claude · عرض قراءة مريح",
@@ -102,7 +111,8 @@
           "minLabel": "أضيق",
           "maxLabel": "أوسع"
         }
-      }
+      },
+      "changelog": "يواكب حدّ عرض العمود الخارجي الجديد في Claude (max-w-[50.5rem]) حتى يعود عرض القراءة إلى العمل."
     }
   },
   "author": "voyager-official",
@@ -124,7 +134,11 @@
         "max": 1600
       }
     },
-    "styles": [{ "file": "style.css" }],
+    "styles": [
+      {
+        "file": "style.css"
+      }
+    ],
     "domOps": [
       {
         "op": "addClass",
@@ -134,7 +148,9 @@
       {
         "op": "setStyle",
         "target": "body",
-        "styles": { "--gv-plugin-reading-width": "{{width}}px" }
+        "styles": {
+          "--gv-plugin-reading-width": "{{width}}px"
+        }
       }
     ]
   }

--- a/src/features/plugins/catalog/sites/claude/plugins/reading-width/style.css
+++ b/src/features/plugins/catalog/sites/claude/plugins/reading-width/style.css
@@ -10,6 +10,16 @@
   max-width: var(--gv-plugin-reading-width, 768px) !important;
 }
 
+/* Claude (September 2026) wraps the turn column in a second cap,
+ * max-w-[50.5rem] (808px = 768px plus the column's 20px side padding). Follow
+ * it with the same padding allowance, otherwise the inner cap widens but its
+ * parent still clamps the column at 808px. Matched structurally, as the parent
+ * of the max-w-3xl column, so the rule survives the next arbitrary-value class
+ * rename. */
+.gv-plugin-claude-readable div:has(> div[class*='max-w-3xl']) {
+  max-width: calc(var(--gv-plugin-reading-width, 768px) + 2.5rem) !important;
+}
+
 .gv-plugin-claude-readable div[class*='items-end']:has([data-testid='user-message']) {
   align-items: flex-start !important;
 }

--- a/src/features/plugins/catalog/sites/claude/plugins/reading-width/style.css
+++ b/src/features/plugins/catalog/sites/claude/plugins/reading-width/style.css
@@ -14,8 +14,8 @@
  * max-w-[50.5rem] (808px = 768px plus the column's 20px side padding). Follow
  * it with the same padding allowance, otherwise the inner cap widens but its
  * parent still clamps the column at 808px. Matched structurally, as the parent
- * of the max-w-3xl column, so the rule survives the next arbitrary-value class
- * rename. */
+ * of the max-w-3xl column, so a rename of the wrapper's own class does not
+ * break it; both rules still depend on max-w-3xl. */
 .gv-plugin-claude-readable div:has(> div[class*='max-w-3xl']) {
   max-width: calc(var(--gv-plugin-reading-width, 768px) + 2.5rem) !important;
 }

--- a/src/features/plugins/catalog/sites/deepseek/plugins/timeline/README.md
+++ b/src/features/plugins/catalog/sites/deepseek/plugins/timeline/README.md
@@ -10,3 +10,7 @@ messages are stored under `deepseek:conv:<id>` and never mix with other sites.
 - Requires Voyager plugin engine 1.4.0 or newer (`requires.handlers: ["turnNavigator"]`).
 - Ships disabled; enable it from the popup on DeepSeek.
 - Status: needs a live check on DeepSeek's virtual list (see issue #996).
+- DeepSeek ships its own message navigator on the right edge. `style.css` hides
+  it while this plugin is mounted (one rail to see, one to click), keyed on the
+  `--scroll-nav-page-padding` custom property DeepSeek sets on the rail's
+  container rather than on its hashed class names.

--- a/src/features/plugins/catalog/sites/deepseek/plugins/timeline/plugin.json
+++ b/src/features/plugins/catalog/sites/deepseek/plugins/timeline/plugin.json
@@ -2,14 +2,14 @@
   "$schema": "https://voyager.nagi.fun/plugin.schema.json",
   "id": "voyager.deepseek-timeline",
   "name": "DeepSeek · Timeline",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Adds a compact conversation timeline to DeepSeek with starred messages and search.",
-  "changelog": "First release: the timeline rail on DeepSeek through the turnNavigator primitive.",
+  "changelog": "Hides DeepSeek's own message navigator while the Voyager timeline is on, so there is one rail to see and to click.",
   "i18n": {
     "zh": {
       "name": "DeepSeek · 时间线",
       "description": "为 DeepSeek 添加紧凑的对话时间线，支持星标消息和搜索。",
-      "changelog": "首个版本：通过 turnNavigator 原语在 DeepSeek 上提供时间线。",
+      "changelog": "开启 Voyager 时间线时隐藏 DeepSeek 自带的消息导航，只保留一条可看可点的轨道。",
       "settings": {
         "compactView": {
           "label": "使用紧凑索引"
@@ -19,7 +19,7 @@
     "zh_TW": {
       "name": "DeepSeek · 時間線",
       "description": "為 DeepSeek 加入緊湊的對話時間線，支援星標訊息與搜尋。",
-      "changelog": "首個版本：透過 turnNavigator 原語在 DeepSeek 上提供時間線。",
+      "changelog": "開啟 Voyager 時間線時隱藏 DeepSeek 內建的訊息導覽，只保留一條可看可點的軌道。",
       "settings": {
         "compactView": {
           "label": "使用精簡索引"
@@ -29,7 +29,7 @@
     "ja": {
       "name": "DeepSeek · タイムライン",
       "description": "DeepSeek にコンパクトな会話タイムラインを追加し、スター付きメッセージと検索に対応します。",
-      "changelog": "初版：turnNavigator プリミティブで DeepSeek にタイムラインを提供します。",
+      "changelog": "Voyager タイムラインが有効な間は DeepSeek 標準のメッセージナビゲーターを隠し、見えるレールと押せるレールを一本にします。",
       "settings": {
         "compactView": {
           "label": "コンパクト表示を使う"
@@ -39,7 +39,7 @@
     "ko": {
       "name": "DeepSeek · 타임라인",
       "description": "DeepSeek에 별표 메시지와 검색을 지원하는 간단한 대화 타임라인을 추가합니다.",
-      "changelog": "첫 릴리스: turnNavigator 프리미티브로 DeepSeek 타임라인을 제공합니다.",
+      "changelog": "Voyager 타임라인이 켜져 있는 동안 DeepSeek 자체 메시지 내비게이터를 숨겨, 보이고 누를 수 있는 레일을 하나로 유지합니다.",
       "settings": {
         "compactView": {
           "label": "컴팩트 타임라인 사용"
@@ -49,7 +49,7 @@
     "fr": {
       "name": "DeepSeek · Timeline",
       "description": "Ajoute une timeline compacte à DeepSeek avec messages favoris et recherche.",
-      "changelog": "Première version : la timeline sur DeepSeek via la primitive turnNavigator.",
+      "changelog": "Masque le navigateur de messages intégré de DeepSeek tant que la timeline Voyager est active, pour n'avoir qu'un seul rail visible et cliquable.",
       "settings": {
         "compactView": {
           "label": "Utiliser la chronologie compacte"
@@ -59,7 +59,7 @@
     "es": {
       "name": "DeepSeek · Línea de tiempo",
       "description": "Añade a DeepSeek una línea de tiempo compacta con mensajes destacados y búsqueda.",
-      "changelog": "Primera versión: la línea de tiempo en DeepSeek mediante la primitiva turnNavigator.",
+      "changelog": "Oculta el navegador de mensajes propio de DeepSeek mientras la línea de tiempo de Voyager está activa, para que haya un solo carril visible y pulsable.",
       "settings": {
         "compactView": {
           "label": "Usar cronología compacta"
@@ -69,7 +69,7 @@
     "pt": {
       "name": "DeepSeek · Linha do tempo",
       "description": "Adiciona ao DeepSeek uma linha do tempo compacta com mensagens favoritas e busca.",
-      "changelog": "Primeira versão: a linha do tempo no DeepSeek pela primitiva turnNavigator.",
+      "changelog": "Oculta o navegador de mensagens do próprio DeepSeek enquanto a linha do tempo do Voyager está ativa, deixando um único trilho visível e clicável.",
       "settings": {
         "compactView": {
           "label": "Usar linha do tempo compacta"
@@ -79,7 +79,7 @@
     "ru": {
       "name": "DeepSeek · Таймлайн",
       "description": "Добавляет в DeepSeek компактную шкалу диалога со звёздами и поиском.",
-      "changelog": "Первая версия: шкала диалога в DeepSeek через примитив turnNavigator.",
+      "changelog": "Скрывает собственный навигатор сообщений DeepSeek, пока включена шкала Voyager, чтобы на экране была одна шкала: видимая и кликабельная.",
       "settings": {
         "compactView": {
           "label": "Использовать компактную шкалу"
@@ -89,7 +89,7 @@
     "ar": {
       "name": "DeepSeek · المخطط الزمني",
       "description": "يضيف إلى DeepSeek مخططًا زمنيًا موجزًا مع الرسائل المميزة والبحث.",
-      "changelog": "الإصدار الأول: المخطط الزمني في DeepSeek عبر الأساسية turnNavigator.",
+      "changelog": "يخفي متصفّح الرسائل المدمج في DeepSeek أثناء تفعيل مخطط Voyager الزمني، فيبقى مسار واحد يمكن رؤيته والنقر عليه.",
       "settings": {
         "compactView": {
           "label": "استخدام المخطط الزمني المضغوط"
@@ -116,6 +116,11 @@
         "default": false
       }
     },
+    "styles": [
+      {
+        "file": "style.css"
+      }
+    ],
     "domOps": [
       {
         "op": "native",

--- a/src/features/plugins/catalog/sites/deepseek/plugins/timeline/style.css
+++ b/src/features/plugins/catalog/sites/deepseek/plugins/timeline/style.css
@@ -1,0 +1,8 @@
+/* DeepSeek ships its own message navigator on the right edge: a fixed rail of
+ * ticks with a hover list. While the Voyager timeline is mounted there must be
+ * one rail to see and one to hit, so the native one is hidden. The hook is the
+ * custom property DeepSeek sets on the rail's container, which outlives its
+ * hashed class names. */
+div[style*='--scroll-nav-page-padding'] {
+  display: none !important;
+}

--- a/src/features/plugins/catalog/sites/deepseek/site.json
+++ b/src/features/plugins/catalog/sites/deepseek/site.json
@@ -7,7 +7,7 @@
     "userTurn": ".ds-message:has(.ds-collapsible-text):not(:has(.ds-assistant-message-main-content, .ds-think-content))",
     "assistantTurn": ".ds-message:has(.ds-assistant-message-main-content, .ds-think-content)",
     "thinkingBlock": ".ds-think-content",
-    "composer": "textarea.ds-scroll-area[placeholder*=\"DeepSeek\" i]"
+    "composer": "textarea.ds-scroll-area"
   },
   "theme": {
     "hostSelector": "body",

--- a/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
+++ b/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
@@ -861,7 +861,7 @@ export class TurnNavigator {
       // landing region mounts, so let the homing loop fine-aim after the jump.
       this.beginPendingNavigation(marker);
       this.pendingNavigationProbed = true;
-      this.scrollToOffset(center, 'auto');
+      this.scrollToOffset(center, 'instant');
       this.schedulePendingNavigationHop();
       return;
     }
@@ -989,7 +989,7 @@ export class TurnNavigator {
       ? marker.center
       : (this.pendingNavigationLo + this.pendingNavigationHi) / 2;
     this.pendingNavigationProbed = true;
-    this.scrollToOffset(probe, 'auto');
+    this.scrollToOffset(probe, 'instant');
     this.schedulePendingNavigationHop();
   };
 
@@ -1123,7 +1123,7 @@ export class TurnNavigator {
    * conversation as Claude re-measures content mid-flight, and mixing smooth
    * short hops with instant long ones read as erratic navigation.
    */
-  private scrollToOffset(center: number, behavior: ScrollBehavior = 'auto'): void {
+  private scrollToOffset(center: number, behavior: ScrollBehavior = 'instant'): void {
     const top = Math.max(0, center - this.getViewportHeight() * ACTIVE_ANCHOR);
     const target = this.scrollTarget;
     if (!target || target === window) {
@@ -1141,7 +1141,7 @@ export class TurnNavigator {
     if (target === window) {
       const top =
         this.getScrollTop() + rect.top + rect.height / 2 - this.getViewportHeight() * ACTIVE_ANCHOR;
-      window.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
+      window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
       return;
     }
     const container = target as HTMLElement;
@@ -1152,7 +1152,7 @@ export class TurnNavigator {
       containerRect.top -
       container.clientHeight * ACTIVE_ANCHOR +
       rect.height / 2;
-    if (container.scrollTo) container.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
+    if (container.scrollTo) container.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
     else container.scrollTop = Math.max(0, top);
   }
 }

--- a/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
+++ b/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
@@ -517,11 +517,23 @@ export class TurnNavigator {
     // drift so re-measured content does not skew the comparison.
     const anchors = matchedKnownIndex.filter((index) => index >= 0);
     const insertBefore = new Map<number, Marker[]>();
-    const file = (block: Marker[], lo: number, hi: number, drift: number): void => {
+    // A known turn between two anchors is assumed to have drifted like the
+    // anchor nearer to it; anchors on different sides of a re-measured region
+    // can carry very different drifts.
+    const driftAt = (index: number, prev: number | undefined, next: number | undefined): number => {
+      const prevDrift = prev === undefined ? undefined : anchorDrift.get(prev);
+      const nextDrift = next === undefined ? undefined : anchorDrift.get(next);
+      if (prevDrift === undefined) return nextDrift ?? 0;
+      if (nextDrift === undefined) return prevDrift;
+      return index - prev! <= next! - index ? prevDrift : nextDrift;
+    };
+    const file = (block: Marker[], prev: number | undefined, next: number | undefined): void => {
       if (!block.length) return;
+      const lo = prev === undefined ? 0 : prev + 1;
+      const hi = next ?? known.length;
       let at = hi;
       for (let index = lo; index < hi; index++) {
-        if (known[index].center + drift > block[0].center) {
+        if (known[index].center + driftAt(index, prev, next) > block[0].center) {
           at = index;
           break;
         }
@@ -530,13 +542,10 @@ export class TurnNavigator {
       if (bucket) bucket.push(...block);
       else insertBefore.set(at, block);
     };
-    file(beforeFirstAnchor, 0, anchors[0], anchorDrift.get(anchors[0]) ?? 0);
+    file(beforeFirstAnchor, undefined, anchors[0]);
     anchors.forEach((anchor, rank) => {
       const block = afterKnownIndex.get(anchor);
-      if (!block) return;
-      const next = anchors[rank + 1];
-      const drift = anchorDrift.get(next ?? anchor) ?? anchorDrift.get(anchor) ?? 0;
-      file(block, anchor + 1, next ?? known.length, drift);
+      if (block) file(block, anchor, anchors[rank + 1]);
     });
 
     const result: Marker[] = [];

--- a/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
+++ b/src/features/plugins/verbs/turnNavigator/TurnNavigator.ts
@@ -63,6 +63,12 @@ const PENDING_NAVIGATION_TIMEOUT_MS = 8000;
 const PENDING_NAVIGATION_HOP_MS = 200;
 const LONG_JUMP_VIEWPORTS = 3;
 const COMPACT_VIEW_SETTING = 'compactView';
+/** Compact ticks keep this pitch until the conversation outgrows the track. */
+const COMPACT_TICK_PITCH_PX = 10;
+/** Room kept at both track ends so the outermost ticks are never clipped. */
+const COMPACT_TRACK_PADDING_PX = 16;
+/** Cluster height used before the track has a layout (first paint, tests). */
+const COMPACT_FALLBACK_SPAN_PX = 240;
 
 export function buildConversationId(
   config: Pick<TurnNavigatorConfig, 'siteId' | 'conversationIdPattern'>,
@@ -474,11 +480,18 @@ export class TurnNavigator {
 
     const beforeFirstAnchor: Marker[] = [];
     const afterKnownIndex = new Map<number, Marker[]>();
+    // Fresh centre minus remembered centre per anchor: how far Claude's
+    // re-measuring has shifted this region since the neighbours were seen.
+    const anchorDrift = new Map<number, number>();
     let lastAnchor = -1;
     for (let i = 0; i < mounted.length; i++) {
       const knownIndex = matchedKnownIndex[i];
       if (knownIndex >= 0) {
         const survivor = known[knownIndex];
+        anchorDrift.set(
+          knownIndex,
+          this.computeElementCenter(mounted[i].element) - survivor.center,
+        );
         survivor.element = mounted[i].element;
         survivor.summary = mounted[i].summary;
         mounted[i].element.dataset.gvTurnId = survivor.id;
@@ -495,14 +508,45 @@ export class TurnNavigator {
       }
     }
 
-    const firstAnchorKnownIndex = matchedKnownIndex[firstMatch];
+    // Anchors fix the order of the turns they match; a block of new turns is
+    // then filed by scroll position among the known turns between its two
+    // bounding anchors. "Right next to the anchor" is not enough: Claude keeps
+    // the latest turn mounted while the reader sits at the top, and that lone
+    // tail anchor would drag the conversation's opening turns behind the
+    // bottom window. Known centres are compared after the nearest anchor's
+    // drift so re-measured content does not skew the comparison.
+    const anchors = matchedKnownIndex.filter((index) => index >= 0);
+    const insertBefore = new Map<number, Marker[]>();
+    const file = (block: Marker[], lo: number, hi: number, drift: number): void => {
+      if (!block.length) return;
+      let at = hi;
+      for (let index = lo; index < hi; index++) {
+        if (known[index].center + drift > block[0].center) {
+          at = index;
+          break;
+        }
+      }
+      const bucket = insertBefore.get(at);
+      if (bucket) bucket.push(...block);
+      else insertBefore.set(at, block);
+    };
+    file(beforeFirstAnchor, 0, anchors[0], anchorDrift.get(anchors[0]) ?? 0);
+    anchors.forEach((anchor, rank) => {
+      const block = afterKnownIndex.get(anchor);
+      if (!block) return;
+      const next = anchors[rank + 1];
+      const drift = anchorDrift.get(next ?? anchor) ?? anchorDrift.get(anchor) ?? 0;
+      file(block, anchor + 1, next ?? known.length, drift);
+    });
+
     const result: Marker[] = [];
     known.forEach((marker, index) => {
-      if (index === firstAnchorKnownIndex) result.push(...beforeFirstAnchor);
+      const block = insertBefore.get(index);
+      if (block) result.push(...block);
       result.push(marker);
-      const extras = afterKnownIndex.get(index);
-      if (extras) result.push(...extras);
     });
+    const tail = insertBefore.get(known.length);
+    if (tail) result.push(...tail);
     return result;
   }
 
@@ -551,6 +595,9 @@ export class TurnNavigator {
       dot.classList.toggle('starred', marker.starred);
       dot.classList.toggle('active', marker.id === this.activeTurnId);
       dot.addEventListener('click', (event) => {
+        // The compact rail is itself the preview-panel toggle: a tick click
+        // must jump, not toggle the panel it bubbles up to.
+        event.stopPropagation();
         if (Date.now() < this.suppressClickUntil) {
           event.preventDefault();
           return;
@@ -572,12 +619,31 @@ export class TurnNavigator {
     });
   }
 
+  /**
+   * Compact ticks keep a fixed pitch and spread over the whole track; the
+   * pitch only shrinks once a conversation outgrows the track. A fixed-height
+   * cluster turned every long conversation into an unreadable barcode.
+   */
   private buildCompactMarkerOffsets(): number[] {
     const count = this.markers.length;
     if (count === 0) return [];
-    const gap = count > 1 ? Math.min(10, 240 / (count - 1)) : 0;
+    const trackHeight = this.trackContent?.parentElement?.clientHeight ?? 0;
+    const span =
+      trackHeight > 0
+        ? Math.max(0, trackHeight - COMPACT_TRACK_PADDING_PX * 2)
+        : COMPACT_FALLBACK_SPAN_PX;
+    const gap = count > 1 ? Math.min(COMPACT_TICK_PITCH_PX, span / (count - 1)) : 0;
     const center = (count - 1) / 2;
     return this.markers.map((_, index) => (index - center) * gap);
+  }
+
+  /** Re-space the existing compact ticks after the track changes height. */
+  private applyCompactOffsets(): void {
+    if (this.timelineStyle !== 'compact') return;
+    const offsets = this.buildCompactMarkerOffsets();
+    this.markers.forEach((marker, index) => {
+      marker.dotElement?.style.setProperty('--timeline-compact-offset', `${offsets[index] ?? 0}px`);
+    });
   }
 
   private startLongPress(dot: Dot): void {
@@ -664,7 +730,9 @@ export class TurnNavigator {
   }
 
   private scheduleTooltip(dot: Dot): void {
-    if (this.disposed) return;
+    // Compact ticks are clickable but stay quiet: the preview panel already
+    // lists every turn while the rail is hovered.
+    if (this.disposed || this.timelineStyle === 'compact') return;
     void this.stopTooltipTimer?.();
     this.stopTooltipTimer = this.scope.timer(() => {
       this.stopTooltipTimer = null;
@@ -673,7 +741,7 @@ export class TurnNavigator {
   }
 
   private showTooltip(dot: Dot): void {
-    if (!this.tooltip || !dot.isConnected) return;
+    if (!this.tooltip || !dot.isConnected || this.timelineStyle === 'compact') return;
     const marker = this.markers.find((item) => item.id === dot.dataset.targetTurnId);
     if (!marker?.summary) return;
 
@@ -780,9 +848,8 @@ export class TurnNavigator {
         this.scrollMarkerIntoView(marker.element);
         return;
       }
-      // Long jump to a mounted turn: smooth-scrolling across a virtualized
-      // conversation drifts as Claude re-measures content mid-flight — jump
-      // instantly, then let the homing loop fine-aim once the region settles.
+      // Long jump to a mounted turn: Claude re-measures content once the
+      // landing region mounts, so let the homing loop fine-aim after the jump.
       this.beginPendingNavigation(marker);
       this.pendingNavigationProbed = true;
       this.scrollToOffset(center, 'auto');
@@ -946,6 +1013,7 @@ export class TurnNavigator {
   };
 
   private handleResize = (): void => {
+    this.applyCompactOffsets();
     this.scheduleRefresh();
     this.previewPanel?.reposition();
   };
@@ -1041,7 +1109,12 @@ export class TurnNavigator {
     );
   }
 
-  private scrollToOffset(center: number, behavior: ScrollBehavior = 'smooth'): void {
+  /**
+   * Every jump is instant. Smooth scrolling drifts across a virtualized
+   * conversation as Claude re-measures content mid-flight, and mixing smooth
+   * short hops with instant long ones read as erratic navigation.
+   */
+  private scrollToOffset(center: number, behavior: ScrollBehavior = 'auto'): void {
     const top = Math.max(0, center - this.getViewportHeight() * ACTIVE_ANCHOR);
     const target = this.scrollTarget;
     if (!target || target === window) {
@@ -1059,7 +1132,7 @@ export class TurnNavigator {
     if (target === window) {
       const top =
         this.getScrollTop() + rect.top + rect.height / 2 - this.getViewportHeight() * ACTIVE_ANCHOR;
-      window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      window.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
       return;
     }
     const container = target as HTMLElement;
@@ -1070,7 +1143,7 @@ export class TurnNavigator {
       containerRect.top -
       container.clientHeight * ACTIVE_ANCHOR +
       rect.height / 2;
-    if (container.scrollTo) container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+    if (container.scrollTo) container.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
     else container.scrollTop = Math.max(0, top);
   }
 }

--- a/src/pages/background/__tests__/contentScriptRegistration.test.ts
+++ b/src/pages/background/__tests__/contentScriptRegistration.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type ContentScriptRegistry,
+  unregisterRegisteredContentScripts,
+} from '../contentScriptRegistration';
+
+/** Mimics Chrome: one unknown id rejects the whole call and removes nothing. */
+function fakeRegistry(initial: readonly string[]) {
+  const registered = new Set(initial);
+  const scripting: ContentScriptRegistry = {
+    getRegisteredContentScripts: vi.fn(async () =>
+      [...registered].map((id) => ({ id, js: [], matches: [] })),
+    ) as unknown as ContentScriptRegistry['getRegisteredContentScripts'],
+    unregisterContentScripts: vi.fn(async (filter?: { ids?: string[] }) => {
+      const ids = filter?.ids ?? [];
+      const missing = ids.find((id) => !registered.has(id));
+      if (missing) throw new Error(`Nonexistent script ID '${missing}'`);
+      for (const id of ids) registered.delete(id);
+    }) as unknown as ContentScriptRegistry['unregisterContentScripts'],
+  };
+  return { scripting, registered };
+}
+
+describe('unregisterRegisteredContentScripts', () => {
+  it('drops only the ids that exist so a never-registered companion cannot block the batch', async () => {
+    const { scripting, registered } = fakeRegistry(['gv-plugin-content-script', 'gv-other']);
+
+    const removed = await unregisterRegisteredContentScripts(scripting, [
+      'gv-plugin-content-script',
+      'gv-plugin-embedded-content-script',
+      'gv-plugin-claude-usage-main',
+    ]);
+
+    expect(removed).toEqual(['gv-plugin-content-script']);
+    expect([...registered]).toEqual(['gv-other']);
+    expect(scripting.unregisterContentScripts).toHaveBeenCalledWith({
+      ids: ['gv-plugin-content-script'],
+    });
+  });
+
+  it('is a no-op when none of the ids are registered', async () => {
+    const { scripting } = fakeRegistry(['gv-other']);
+    await expect(
+      unregisterRegisteredContentScripts(scripting, ['gv-plugin-content-script']),
+    ).resolves.toEqual([]);
+    expect(scripting.unregisterContentScripts).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the whole batch when the registry cannot be listed', async () => {
+    const { scripting, registered } = fakeRegistry(['gv-plugin-content-script']);
+    (scripting.getRegisteredContentScripts as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('boom'),
+    );
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      unregisterRegisteredContentScripts(scripting, ['gv-plugin-content-script']),
+    ).resolves.toEqual(['gv-plugin-content-script']);
+    expect(registered.size).toBe(0);
+    vi.restoreAllMocks();
+  });
+});

--- a/src/pages/background/__tests__/contentScriptRegistration.test.ts
+++ b/src/pages/background/__tests__/contentScriptRegistration.test.ts
@@ -47,17 +47,18 @@ describe('unregisterRegisteredContentScripts', () => {
     expect(scripting.unregisterContentScripts).not.toHaveBeenCalled();
   });
 
-  it('falls back to the whole batch when the registry cannot be listed', async () => {
+  it('unregisters one id at a time when the registry cannot be listed, so an absent id blocks nothing', async () => {
     const { scripting, registered } = fakeRegistry(['gv-plugin-content-script']);
     (scripting.getRegisteredContentScripts as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('boom'),
     );
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await expect(
-      unregisterRegisteredContentScripts(scripting, ['gv-plugin-content-script']),
+      unregisterRegisteredContentScripts(scripting, [
+        'gv-plugin-content-script',
+        'gv-plugin-embedded-content-script',
+      ]),
     ).resolves.toEqual(['gv-plugin-content-script']);
     expect(registered.size).toBe(0);
-    vi.restoreAllMocks();
   });
 });

--- a/src/pages/background/contentScriptRegistration.ts
+++ b/src/pages/background/contentScriptRegistration.ts
@@ -1,0 +1,45 @@
+/**
+ * Dynamic content-script registration helpers for the background worker.
+ *
+ * Chrome rejects the whole `unregisterContentScripts` call when any id in it
+ * is unknown ("Nonexistent script ID"), and the `registerContentScripts` that
+ * follows then fails on the duplicate id. Batching a never-registered
+ * companion script (the Claude usage bridge, the embedded-frame script) into
+ * one unregister call therefore froze the plugin registration on its first
+ * result: enabling a plugin for a new site later changed nothing until the
+ * extension restarted.
+ */
+
+export type ContentScriptRegistry = Pick<
+  typeof chrome.scripting,
+  'getRegisteredContentScripts' | 'unregisterContentScripts'
+>;
+
+/**
+ * Unregister only the ids that are actually registered. Returns the ids that
+ * were removed; a missing id is not an error.
+ */
+export async function unregisterRegisteredContentScripts(
+  scripting: ContentScriptRegistry | undefined,
+  ids: readonly string[],
+): Promise<string[]> {
+  if (!scripting?.unregisterContentScripts) return [];
+  let registered: string[];
+  try {
+    const wanted = new Set(ids);
+    registered = (await scripting.getRegisteredContentScripts())
+      .map((script) => script.id)
+      .filter((id) => wanted.has(id));
+  } catch {
+    // Listing failed: try the whole batch, which at worst rejects as before.
+    registered = [...ids];
+  }
+  if (!registered.length) return [];
+  try {
+    await scripting.unregisterContentScripts({ ids: registered });
+    return registered;
+  } catch (error) {
+    console.warn('[Background] Failed to unregister content scripts', registered, error);
+    return [];
+  }
+}

--- a/src/pages/background/contentScriptRegistration.ts
+++ b/src/pages/background/contentScriptRegistration.ts
@@ -31,8 +31,18 @@ export async function unregisterRegisteredContentScripts(
       .map((script) => script.id)
       .filter((id) => wanted.has(id));
   } catch {
-    // Listing failed: try the whole batch, which at worst rejects as before.
-    registered = [...ids];
+    // Listing failed: unregister one id at a time, so an absent id can only
+    // fail its own call instead of the whole batch.
+    const removed: string[] = [];
+    for (const id of ids) {
+      try {
+        await scripting.unregisterContentScripts({ ids: [id] });
+        removed.push(id);
+      } catch {
+        // Not registered.
+      }
+    }
+    return removed;
   }
   if (!registered.length) return [];
   try {

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -98,6 +98,7 @@ import type { StarredMessage, StarredMessagesData } from '@/pages/content/timeli
 import { getTranslation } from '@/utils/i18n';
 import type { TranslationKey } from '@/utils/translations';
 
+import { unregisterRegisteredContentScripts } from './contentScriptRegistration';
 import { resolveOptionalHighlightSetting } from './highlightOptionalSetting';
 import {
   isAllowedSyncContentSender,
@@ -1121,17 +1122,11 @@ async function doSyncPluginContentScripts(): Promise<void> {
   const origins = await getEnabledPluginOrigins();
   const grantedMatches = await filterGrantedOrigins(origins);
 
-  try {
-    await chrome.scripting.unregisterContentScripts({
-      ids: [
-        PLUGIN_CONTENT_SCRIPT_ID,
-        PLUGIN_EMBEDDED_CONTENT_SCRIPT_ID,
-        CLAUDE_USAGE_MAIN_SCRIPT_ID,
-      ],
-    });
-  } catch {
-    // No-op if the script was not registered.
-  }
+  await unregisterRegisteredContentScripts(chrome.scripting, [
+    PLUGIN_CONTENT_SCRIPT_ID,
+    PLUGIN_EMBEDDED_CONTENT_SCRIPT_ID,
+    CLAUDE_USAGE_MAIN_SCRIPT_ID,
+  ]);
 
   if (!grantedMatches.length) return;
 


### PR DESCRIPTION
Stacked on #1001 (layer 5 of stack #1002). Fixes found while live-testing the Claude timeline; none of them were introduced by the extraction in #1001, the engine had these on `main` too.

## Turn navigator (Claude, DeepSeek)

- **Order.** Claude now keeps the latest turn mounted while the reader sits at the top, so stitching a freshly mounted block "right before its first anchor" filed the conversation's opening turns behind the bottom window: rail, preview list and active marker were all wrong after one scroll up. Blocks are now filed by scroll position between their bounding anchors, comparing known centres after the nearest anchor's re-measure drift.
- **Compact density.** Ticks keep a fixed 10px pitch and spread over the whole track instead of a 240px cluster that turned long conversations into a barcode; re-spaced on resize.
- **Compact ticks are clickable.** A tick click jumps to its turn (propagation stopped so the rail's panel toggle does not fire); hovering the rail still opens the preview; no tooltip in compact mode.
- **Every jump is instant.** Navigation no longer alternates between smooth short hops and instant long ones (smooth scrolling drifts across Claude's virtualized DOM anyway).

## Catalog

- DeepSeek's `composer` selector no longer depends on the placeholder text, which chat.deepseek.com now renders as "给 DSeek 发送消息".
- **Claude reading width** (1.4.1): Claude wraps the turn column in a second cap, `max-w-[50.5rem]` (808px), so widening `max-w-3xl` alone left the column clamped. The wrapper is widened too, matched as the parent of the `max-w-3xl` column. Plugin CSS was untouched by the catalog refactor; this is a Claude DOM change.
- **DeepSeek timeline** (1.1.0): hides DeepSeek's own right-edge message navigator while the Voyager timeline is mounted, keyed on the `--scroll-nav-page-padding` custom property DeepSeek sets on its container rather than on hashed class names.

## Background

- **Plugin content-script registration froze after its first sync.** The sync batched the plugin, embedded-frame and Claude-usage script ids into one `unregisterContentScripts` call; Chrome rejects the whole call when any id is unknown, and the following `registerContentScripts` then failed on the duplicate id. Enabling the DeepSeek plugins after ChatGPT/Claude were registered changed nothing until the extension restarted, while the popup showed the toggles on. Pre-existing on `main`. The sync now unregisters only the ids that exist (`contentScriptRegistration.ts`, unit-tested against Chrome's atomic rejection).

## Verification

- `bun run verify:pr` on this layer: 359 test files / 3784 tests, plugin:check, Chrome build, docs build.
- Four new guards in `src/features/plugins/builtin/claudeTimeline/index.test.ts`; against the previous engine 10 assertions in that file fail.
- Regression notes: two new sections in `.github/docs/regressions/folders-timeline-ui.md`.
- Live on claude.ai: after a scroll to the top the rail lists the opening turns first, compact ticks sit at a 10px pitch, are clickable and jump instantly without toggling the panel. Live on chat.deepseek.com: reading width, formula copy and the timeline mount, and the native navigator is hidden (`display: none`, the right edge hits only the Voyager rail). Live on claude.ai at the 1600px setting: wrapper 1640px, column 1600px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVUBXiVusYPrQa54FsffLG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compact timeline ticks are clickable, evenly spaced, and resize-aware.
  - Hovering over compact timeline rails opens previews without changing preview state.
  - Claude’s reading-width plugin supports Claude’s updated conversation layout.
  - DeepSeek’s built-in message navigator is hidden while the Voyager timeline is active.

- **Bug Fixes**
  - Timeline navigation now jumps instantly and more accurately across long distances.
  - Improved turn ordering in sparse or virtualized conversation histories.
  - DeepSeek message composition works with more composer fields.
  - Plugin content scripts are removed more reliably during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turn-navigator stitching and scroll behavior affect Claude/DeepSeek timeline UX across virtualization; background registration fixes a session-stuck injection bug but touches extension-wide plugin sync.
> 
> **Overview**
> Fixes **turn navigator** behavior on Claude’s sparse virtualized DOM and tightens related catalog/background issues found in live testing.
> 
> **Turn navigator (`TurnNavigator.ts`).** Unknown turn blocks are no longer stitched “before the first anchor”; they are **inserted by scroll position** between bounding anchors, with **anchor drift** applied when comparing centres—so opening turns stay ahead of a bottom window when the latest turn stays mounted. **Compact mode** spreads ticks across the full track (fixed pitch, shrink only when needed, re-space on resize), **tick clicks jump** (`stopPropagation`, no tooltip), and **all navigation uses `behavior: 'instant'`** so virtualized re-measure doesn’t fight smooth scroll. CSS re-enables pointer events on `[data-gv-turn-navigator]` compact rails.
> 
> **Background.** Plugin content-script sync now **unregisters only ids Chrome actually has registered** via `contentScriptRegistration.ts`, avoiding a failed batch unregister that froze re-registration until restart.
> 
> **Catalog.** Claude **reading-width 1.4.1** widens the new outer `max-w-[50.5rem]` wrapper; DeepSeek **timeline 1.1.0** hides the native message navigator; DeepSeek **`composer`** selector drops placeholder-text dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de53d3beb44efb3bce9bbc43e0537b8b47f08b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

