### PR TITLE
fix(export): skip ChatGPT bookkeeping roots and blank turns instead of failing

### DIFF
--- a/.github/docs/regressions/providers-plugins.md
+++ b/.github/docs/regressions/providers-plugins.md
@@ -16,6 +16,26 @@ or prompt commands.
 - **Guard:** `src/pages/content/export/adapter/__tests__/chatgpt.test.ts`
   (`repositions a virtual shell that moves offscreen after height reconciliation`).
 
+## ChatGPT bookkeeping roots and message-less turns must not abort the export
+
+- **Trap:** Exporting a ChatGPT conversation opened from history failed with
+  `chatgpt_export_message_unavailable:paginated-root:<conversation-id>`, surfaced to the user as the
+  generic "refresh and retry" alert, and select mode showed a phantom checkbox above the first
+  message. ChatGPT stores its virtual-list roots in the same `data-turn-id-container` attribute as
+  turns: `client-created-root` for a conversation started in the tab and `paginated-root:<id>` for
+  one opened from history; only the first was excluded. A turn whose response rendered nothing
+  (`section[data-turn="assistant"]` without any `[data-message-author-role]`) then hit the same
+  timeout because it looked like an unmounted virtual shell.
+- **Rule:** Skip every `*-root` container. Resolve the role from `[data-turn]` when no message root
+  exists, and once a mounted frame stays message-less through the settle window treat the turn as
+  empty: count it as handled, export nothing for it, and keep pairing sequence-based so the
+  preceding prompt becomes a user-only turn. A frame-less shell must still time out.
+- **Guard:** `src/pages/content/export/adapter/__tests__/chatgpt.test.ts`
+  (`ignores the paginated history root the same way`,
+  `resolves the role from the turn frame when ChatGPT renders a turn without a message`,
+  `skips a rendered turn without a message instead of failing the export`,
+  `fails when a selected virtual shell never mounts`).
+
 ## ChatGPT export toolbar must avoid the native header cluster
 
 - **Trap:** The ChatGPT persistent export button sat at `top: 50px` / `right: 84px` and covered

--- a/src/pages/content/export/adapter/__tests__/chatgpt.test.ts
+++ b/src/pages/content/export/adapter/__tests__/chatgpt.test.ts
@@ -102,6 +102,32 @@ describe('chatgptCollectTurnContainers', () => {
     expect(turns.map((turn) => turn.sequence)).toEqual([0, 1]);
   });
 
+  it('ignores the paginated history root the same way', () => {
+    document.body.innerHTML = `
+      <div data-turn-id-container="paginated-root:6a9f32f7-3a38-83eb-92c4-0737641a943d"></div>
+      <div data-turn-id-container="user-1">
+        <div data-message-author-role="user">First prompt</div>
+      </div>
+    `;
+
+    expect(chatgptCollectTurnContainers().map((turn) => turn.id)).toEqual(['user-1']);
+  });
+
+  it('resolves the role from the turn frame when ChatGPT renders a turn without a message', () => {
+    document.body.innerHTML = `
+      <div data-turn-id-container="assistant-1">
+        <section data-turn="assistant" data-turn-id-container="assistant-1">
+          <h4>ChatGPT said:</h4>
+          <div></div>
+        </section>
+      </div>
+    `;
+
+    const [turn] = chatgptCollectTurnContainers();
+
+    expect(turn.role).toBe('assistant');
+  });
+
   it('keeps only the first container for each stable turn id', () => {
     document.body.innerHTML = `
       <div data-turn-id-container="user-1">
@@ -310,6 +336,33 @@ describe('chatgptCollectTurnContainers', () => {
     );
     await vi.advanceTimersByTimeAsync(3200);
     await assertion;
+  });
+
+  it('skips a rendered turn without a message instead of failing the export', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div data-turn-id-container="user-1"><div data-message-author-role="user">U1</div></div>
+      <div data-turn-id-container="assistant-1">
+        <section data-turn="assistant" data-turn-id-container="assistant-1">
+          <h4>ChatGPT said:</h4>
+          <div></div>
+        </section>
+      </div>
+      <div data-turn-id-container="user-2"><div data-message-author-role="user">U2</div></div>
+      <div data-turn-id-container="assistant-2">
+        <div data-message-author-role="assistant">A2</div>
+      </div>
+    `;
+
+    const exportPromise = buildChatGptTurnsForSelection(
+      new Set(['user-1', 'assistant-1', 'user-2', 'assistant-2']),
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(exportPromise).resolves.toMatchObject([
+      { user: 'U1', assistant: '' },
+      { user: 'U2', assistant: 'A2' },
+    ]);
   });
 
   it('repositions a virtual shell that moves offscreen after height reconciliation', async () => {

--- a/src/pages/content/export/adapter/chatgpt.ts
+++ b/src/pages/content/export/adapter/chatgpt.ts
@@ -8,7 +8,11 @@ import { computeConversationFingerprint } from '../topNodePreload';
 import type { ChatGptTurnContainer, ChatGptTurnRole, ExportSelectionOptions } from './type';
 
 const TURN_CONTAINER_SELECTOR = '[data-turn-id-container]';
-const NON_TURN_CONTAINER_IDS = new Set(['client-created-root']);
+// ChatGPT stores virtual-list bookkeeping roots in the same attribute as turns:
+// `client-created-root` for a conversation started in this tab and
+// `paginated-root:<conversation-id>` for one opened from history.
+const NON_TURN_CONTAINER_ID = /-root(?::|$)/;
+const TURN_FRAME_SELECTOR = '[data-turn]';
 const USER_MESSAGE_SELECTOR = '[data-message-author-role="user"]';
 const ASSISTANT_MESSAGE_SELECTOR = '[data-message-author-role="assistant"]';
 const IMAGEGEN_SELECTOR = '[class*="group/imagegen-image"]';
@@ -43,7 +47,19 @@ function resolveTurnRole(container: HTMLElement): ChatGptTurnRole {
     return 'assistant';
   }
 
-  return 'unknown';
+  return resolveTurnFrameRole(container);
+}
+
+function findTurnFrame(container: HTMLElement): Element | null {
+  return container.matches(TURN_FRAME_SELECTOR)
+    ? container
+    : container.querySelector(TURN_FRAME_SELECTOR);
+}
+
+/** ChatGPT labels the rendered turn frame (`section[data-turn]`) even when it holds no message. */
+function resolveTurnFrameRole(container: HTMLElement): ChatGptTurnRole {
+  const role = findTurnFrame(container)?.getAttribute('data-turn');
+  return role === 'user' || role === 'assistant' ? role : 'unknown';
 }
 
 function mergeExtractedContent(
@@ -89,7 +105,7 @@ export function chatgptCollectTurnContainers(root: ParentNode = document): ChatG
 
   for (const container of root.querySelectorAll<HTMLElement>(TURN_CONTAINER_SELECTOR)) {
     const id = container.getAttribute('data-turn-id-container')?.trim();
-    if (!id || NON_TURN_CONTAINER_IDS.has(id)) continue;
+    if (!id || NON_TURN_CONTAINER_ID.test(id)) continue;
 
     const role = resolveTurnRole(container);
     const existing = turnsById.get(id);
@@ -193,6 +209,22 @@ function hasConventionalMountedContent(root: HTMLElement): boolean {
   );
 }
 
+/**
+ * A turn whose frame ChatGPT rendered but that holds no message root at all,
+ * for example a response that only produced a file which is no longer shown.
+ * Unlike an unmounted virtual shell, the frame proves ChatGPT already laid the
+ * turn out, so waiting for content cannot succeed.
+ */
+function isRenderedWithoutMessage(turn: ChatGptTurnContainer): boolean {
+  const { container } = turn;
+  return (
+    findTurnFrame(container) != null &&
+    container.querySelector(
+      `${USER_MESSAGE_SELECTOR},${ASSISTANT_MESSAGE_SELECTOR},${IMAGEGEN_SELECTOR}`,
+    ) == null
+  );
+}
+
 function isGeneratingTurn(turn: ChatGptTurnContainer): boolean {
   if (
     turn.container.matches(STREAMING_TURN_SELECTOR) ||
@@ -208,6 +240,8 @@ function isGeneratingTurn(turn: ChatGptTurnContainer): boolean {
 /**
  * Materialize a virtualized ChatGPT turn. Already-mounted, completed turns use
  * a zero-wait fast path; empty shells wait for a positive role/content signal.
+ * A rendered turn that stays message-less through the idle window is returned
+ * with `empty: true` instead of timing out.
  */
 export async function materializeChatGptTurnContainer(
   turn: ChatGptTurnContainer,
@@ -234,7 +268,13 @@ export async function materializeChatGptTurnContainer(
     if (latest) current = { ...latest, role: resolveTurnRole(latest.container) };
 
     const hasContent = current.role !== 'unknown' && hasMountedContent(current);
-    if (!hasContent && Date.now() - lastPositionAt >= MATERIALIZATION_REPOSITION_MS) {
+    const renderedEmpty =
+      !hasContent && current.role !== 'unknown' && isRenderedWithoutMessage(current);
+    if (
+      !hasContent &&
+      !renderedEmpty &&
+      Date.now() - lastPositionAt >= MATERIALIZATION_REPOSITION_MS
+    ) {
       const rect = current.container.getBoundingClientRect();
       if (rect.bottom <= 0 || rect.top >= window.innerHeight) {
         // ChatGPT reconciles estimated shell heights after nearby turns mount.
@@ -245,14 +285,14 @@ export async function materializeChatGptTurnContainer(
       }
     }
 
-    if (hasContent && !isGeneratingTurn(current)) {
+    if ((hasContent || renderedEmpty) && !isGeneratingTurn(current)) {
       const fingerprint = computeConversationFingerprint(current.container, contentSelectors, 10);
       const signature = `${fingerprint.signature}:${fingerprint.count}`;
       if (signature !== stableSignature) {
         stableSignature = signature;
         stableSince = Date.now();
       } else if (Date.now() - stableSince >= MATERIALIZATION_IDLE_MS) {
-        return current;
+        return renderedEmpty ? { ...current, empty: true } : current;
       }
     } else {
       stableSignature = '';
@@ -366,12 +406,19 @@ export async function buildChatGptTurnsForSelection(
 
   const turns: ChatTurn[] = [];
   let pendingUser: { readonly turn: ChatTurn; readonly sequence: number } | null = null;
-  const extractedIds = new Set<string>();
+  const handledIds = new Set<string>();
 
   try {
     for (const turn of selectedContainers) {
       assertSelectionActive(options);
       const materialized = await materializeChatGptTurnContainer(turn, options);
+      if (materialized.empty) {
+        // Nothing to export for this turn, but not a failure: ChatGPT itself
+        // shows it blank. Pairing stays sequence-based, so a prompt followed by
+        // a blank response exports as a user-only turn.
+        handledIds.add(turn.id);
+        continue;
+      }
       const { container, role } = materialized;
       const sequence = turn.sequence;
 
@@ -397,7 +444,7 @@ export async function buildChatGptTurnsForSelection(
             userContent,
           },
         };
-        extractedIds.add(turn.id);
+        handledIds.add(turn.id);
         continue;
       }
 
@@ -431,7 +478,7 @@ export async function buildChatGptTurnsForSelection(
             assistantContent,
           });
         }
-        extractedIds.add(turn.id);
+        handledIds.add(turn.id);
         continue;
       }
 
@@ -439,7 +486,7 @@ export async function buildChatGptTurnsForSelection(
     }
 
     if (pendingUser) turns.push(pendingUser.turn);
-    if (extractedIds.size !== selectedContainerIds.size) {
+    if (handledIds.size !== selectedContainerIds.size) {
       throw new Error('chatgpt_export_incomplete_selection');
     }
 

--- a/src/pages/content/export/adapter/type.ts
+++ b/src/pages/content/export/adapter/type.ts
@@ -12,6 +12,12 @@ export interface ChatGptTurnContainer {
 
   /** 顶层 [data-turn-id-container] 容器。 */
   container: HTMLElement;
+
+  /**
+   * ChatGPT 渲染了该 turn 的外框，但其中没有任何消息（例如只产出了已不再展示的文件的回复）。
+   * 仅由 materialize 在内容稳定为空后设置。
+   */
+  empty?: boolean;
 }
 
 export interface ExportSelectionOptions {


### PR DESCRIPTION
## Problem

Exporting a ChatGPT conversation opened from history failed after a 3 s timeout with `chatgpt_export_message_unavailable:paginated-root:<conversation-id>`, which the UI shows as the generic "refresh and retry" alert. Select mode also showed a phantom checkbox above the first message.

Two ChatGPT DOM shapes caused it:

1. ChatGPT stores its virtual-list roots in the same `data-turn-id-container` attribute as turns: `client-created-root` for a conversation started in the tab and `paginated-root:<conversation-id>` for one loaded from history. Only the first was excluded, so the second was treated as a turn that never mounts.
2. A turn whose response rendered nothing (a `section[data-turn="assistant"]` frame with no `[data-message-author-role]`) hit the same timeout because it looked like an unmounted virtual shell.

## Change

- Skip every `*-root` container.
- Resolve the role from `[data-turn]` when no message root exists.
- Once a mounted frame stays message-less through the settle window, return it as `empty`; the export counts it as handled and emits nothing for it, so the preceding prompt becomes a user-only turn. A frame-less shell still times out as before.
- Regression note under providers-plugins.

## Verification

- `bun run test src/pages/content/export` (19 files, 169 tests, 3 new), `bun run typecheck`, `bun run lint:check`, `bun run regressions:check`, `bun run build:chrome`.
- Live on the affected conversation: Markdown export succeeds, the blank response is skipped, the docx attachment is listed on the user turn, and the phantom checkbox is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVUBXiVusYPrQa54FsffLG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ChatGPT export materialization and turn pairing for DOM edge cases; behavior is covered by new tests but could affect export output shape for conversations with blank or history-root quirks.
> 
> **Overview**
> Fixes ChatGPT export failures on **history-loaded conversations** and on turns that render an empty assistant frame, which previously surfaced as `chatgpt_export_message_unavailable` (including phantom select-mode checkboxes for `paginated-root:*`).
> 
> **Bookkeeping roots:** Turn collection now skips any `data-turn-id-container` whose id matches `*-root` (not only `client-created-root`), so `paginated-root:<conversation-id>` is no longer treated as a message that never mounts.
> 
> **Message-less turns:** When there is no `[data-message-author-role]` but ChatGPT did render a `section[data-turn]`, role comes from that frame. If the turn stays message-less through the materialization settle window, it is marked **`empty`**, counted as handled, omitted from export output, and sequence pairing still yields a **user-only** turn for the preceding prompt. Frame-less virtual shells still time out as before.
> 
> Regression notes and adapter tests cover paginated roots, frame-based roles, skipping blank turns, and unchanged failure for shells that never mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0250b6c46ae55715db9f408dbd4d47854a7e51fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ChatGPT exports failing when conversations were opened from history.
  * Prevented phantom checkboxes and generic refresh errors caused by virtual-list elements.
  * Improved handling of assistant turns with no visible message, allowing the rest of the conversation to export successfully.
  * Preserved correct prompt and response pairing when empty assistant turns are encountered.

* **Documentation**
  * Added a regression note covering the affected ChatGPT export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->