### PR TITLE
fix(export): show the ChatGPT export entry only where a conversation can exist

### DIFF
--- a/.github/docs/regressions/providers-plugins.md
+++ b/.github/docs/regressions/providers-plugins.md
@@ -16,6 +16,19 @@ or prompt commands.
 - **Guard:** `src/pages/content/export/adapter/__tests__/chatgpt.test.ts`
   (`repositions a virtual shell that moves offscreen after height reconciliation`).
 
+## ChatGPT export entry point only where a conversation can exist
+
+- **Trap:** The ChatGPT export plugin matches the whole origin, and the persistent toolbar was
+  mounted as soon as the plugin started, so it also appeared on Codex, settings and library pages
+  where nothing can be exported, and stayed there as the SPA moved between such pages and chats.
+- **Rule:** Platforms whose chat UI shares an origin with unrelated pages implement
+  `isConversationPage(doc, url)` on their export adapter; `startExportEntryGate` mounts the entry
+  point only while it returns true and re-checks on route changes and settled DOM mutations. For
+  ChatGPT that is a `/c/<id>` route (optionally under `/u/<n>/` or `/g/<gpt>/`) or a rendered
+  turn, because a temporary chat keeps `/?temporary-chat=true`.
+- **Guard:** `src/pages/content/export/adapter/__tests__/chatgpt.test.ts`
+  (`chatgptIsConversationPage`), `src/pages/content/export/__tests__/exportEntryGate.test.ts`.
+
 ## ChatGPT export toolbar must avoid the native header cluster
 
 - **Trap:** The ChatGPT persistent export button sat at `top: 50px` / `right: 84px` and covered

--- a/src/pages/content/export/__tests__/exportEntryGate.test.ts
+++ b/src/pages/content/export/__tests__/exportEntryGate.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { startExportEntryGate } from '../exportEntryGate';
+
+describe('startExportEntryGate', () => {
+  let eligible: boolean;
+  let routeListener: (() => void) | null;
+  const mount = vi.fn();
+  const unmount = vi.fn();
+  const stopRouteWatch = vi.fn();
+  const watchRoute = (listener: () => void): (() => void) => {
+    routeListener = listener;
+    return stopRouteWatch;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eligible = false;
+    routeListener = null;
+    mount.mockClear();
+    unmount.mockClear();
+    stopRouteWatch.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  let stopGate: (() => void) | null = null;
+
+  afterEach(() => {
+    // A gate left running would keep observing document.body into the next test.
+    stopGate?.();
+    stopGate = null;
+    vi.useRealTimers();
+  });
+
+  const start = (): (() => void) => {
+    stopGate = startExportEntryGate({
+      isEligible: () => eligible,
+      mount,
+      unmount,
+      watchRoute,
+      root: document.body,
+      settleMs: 50,
+    });
+    return stopGate;
+  };
+
+  it('mounts only once the route reaches a conversation and unmounts when it leaves', () => {
+    const stop = start();
+    expect(mount).not.toHaveBeenCalled();
+
+    eligible = true;
+    routeListener?.();
+    expect(mount).toHaveBeenCalledTimes(1);
+    // A second notification while still eligible does not remount.
+    routeListener?.();
+    expect(mount).toHaveBeenCalledTimes(1);
+
+    eligible = false;
+    routeListener?.();
+    expect(unmount).toHaveBeenCalledTimes(1);
+    stop();
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(stopRouteWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('notices a conversation that renders without a route change', async () => {
+    start();
+    eligible = true;
+    document.body.appendChild(document.createElement('div'));
+    document.body.appendChild(document.createElement('div'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mount).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60);
+    // One settle window per burst of mutations.
+    expect(mount).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmounts whatever is mounted on teardown and ignores later signals', async () => {
+    eligible = true;
+    const stop = start();
+    expect(mount).toHaveBeenCalledTimes(1);
+    stop();
+    expect(unmount).toHaveBeenCalledTimes(1);
+
+    eligible = false;
+    routeListener?.();
+    document.body.appendChild(document.createElement('div'));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/content/export/adapter/__tests__/chatgpt.test.ts
+++ b/src/pages/content/export/adapter/__tests__/chatgpt.test.ts
@@ -8,6 +8,7 @@ import {
   isChatGptResponseGenerating,
   resolveChatGptSelectionRoles,
 } from '../chatgpt';
+import { chatgptIsConversationPage } from '../platform/chatgpt';
 import type { ExportPlatformAdapter } from '../platformAdapters';
 
 const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
@@ -67,6 +68,43 @@ afterEach(() => {
   } else {
     delete (HTMLElement.prototype as { scrollIntoView?: unknown }).scrollIntoView;
   }
+});
+
+describe('chatgptIsConversationPage', () => {
+  it('accepts conversation routes, with or without a GPT or account prefix', () => {
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/c/6a9f32f7-3a38')).toBe(true);
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/g/g-abc/c/6a9f32f7')).toBe(
+      true,
+    );
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/u/1/c/6a9f32f7')).toBe(true);
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/c/6a9f?model=gpt-5')).toBe(
+      true,
+    );
+  });
+
+  it('rejects the pages ChatGPT serves from the same origin without a conversation', () => {
+    expect(
+      chatgptIsConversationPage(
+        document,
+        'https://chatgpt.com/codex/cloud/settings/analytics#code-review',
+      ),
+    ).toBe(false);
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/')).toBe(false);
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/g/g-abc')).toBe(false);
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/library')).toBe(false);
+    expect(chatgptIsConversationPage(document, 'not a url')).toBe(false);
+  });
+
+  it('accepts a rendered turn on any route, as a temporary chat never leaves the root', () => {
+    document.body.innerHTML = `
+      <div data-turn-id-container="user-1">
+        <div data-message-author-role="user">hello</div>
+      </div>
+    `;
+    expect(chatgptIsConversationPage(document, 'https://chatgpt.com/?temporary-chat=true')).toBe(
+      true,
+    );
+  });
 });
 
 describe('chatgptCollectTurnContainers', () => {

--- a/src/pages/content/export/adapter/platform/chatgpt.ts
+++ b/src/pages/content/export/adapter/platform/chatgpt.ts
@@ -31,6 +31,27 @@ function extractId(): string | null {
 
 const ROOT_CANDIDATES = ['main', '[role="main"]'];
 
+/** `/c/<id>` or `/g/<gpt>/c/<id>`, optionally under `/u/<index>/`. */
+const CONVERSATION_ROUTE = /^(?:\/u\/[^/]+)?(?:\/g\/[^/]+)?\/c\/[^/?#]+/;
+/** A turn ChatGPT has actually rendered, whatever the route says. */
+const MOUNTED_TURN_SELECTOR =
+  '[data-turn-id-container] [data-message-author-role], [data-turn-id-container][data-turn], section[data-turn]';
+
+/**
+ * ChatGPT serves Codex, settings and other non-chat pages from the same
+ * origin. A conversation lives on a `/c/<id>` route, or, for a temporary chat
+ * that never leaves `/?temporary-chat=true`, wherever a turn is rendered.
+ */
+export function chatgptIsConversationPage(doc: Document, url: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return false;
+  }
+  return CONVERSATION_ROUTE.test(pathname) || doc.querySelector(MOUNTED_TURN_SELECTOR) !== null;
+}
+
 function resolveRoot(_userSelectors: string[], doc: Document = document): HTMLElement {
   for (const selector of ROOT_CANDIDATES) {
     const element = doc.querySelector<HTMLElement>(selector);
@@ -219,6 +240,7 @@ export function buildChatGptAdapter(site: SiteAdapter): ExportPlatformAdapter {
     extractConversationTitle: extractTitle,
     extractConversationIdFromUrl: extractId,
     shouldPreloadHistory: () => false,
+    isConversationPage: chatgptIsConversationPage,
     resolveConversationRoot: resolveRoot,
     extractUserImage,
     extractUserText: chatgptExtractUserText,

--- a/src/pages/content/export/adapter/platform/contract.ts
+++ b/src/pages/content/export/adapter/platform/contract.ts
@@ -57,6 +57,14 @@ export interface ExportPlatformAdapter {
     textParts: string[],
   ) => boolean | undefined;
 
+  /**
+   * Whether this page can hold a conversation. Hosts whose chat UI shares the
+   * origin with unrelated pages (ChatGPT: Codex, settings) return false there,
+   * and the export entry point stays unmounted until the SPA reaches a
+   * conversation. Omitted: every page on the host is eligible.
+   */
+  isConversationPage?: (doc: Document, url: string) => boolean;
+
   collectTurnContainers?: () => ChatGptTurnContainer[];
   buildTurnsForSelection?: (
     selectedMessageIds: ReadonlySet<string>,

--- a/src/pages/content/export/exportEntryGate.ts
+++ b/src/pages/content/export/exportEntryGate.ts
@@ -1,0 +1,67 @@
+export interface ExportEntryGateOptions {
+  /** Whether the current page can hold a conversation. Read on every check. */
+  readonly isEligible: () => boolean;
+  readonly mount: () => void;
+  readonly unmount: () => void;
+  /** SPA route watcher; returns its unsubscribe. */
+  readonly watchRoute: (listener: () => void) => () => void;
+  /** Subtree watched for a conversation that appears without a route change. */
+  readonly root: Node;
+  /** Quiet period after a DOM mutation before re-checking. */
+  readonly settleMs?: number;
+}
+
+const DEFAULT_SETTLE_MS = 300;
+
+/**
+ * Keeps an export entry point mounted exactly while the page is eligible.
+ *
+ * Route changes are the usual trigger. DOM mutations are watched too because
+ * a conversation can appear without one: a ChatGPT temporary chat stays on
+ * `/?temporary-chat=true` while its turns render. Returns the teardown, which
+ * also unmounts whatever is mounted.
+ */
+export function startExportEntryGate(options: ExportEntryGateOptions): () => void {
+  const settleMs = options.settleMs ?? DEFAULT_SETTLE_MS;
+  let mounted = false;
+  let disposed = false;
+  let settleTimer: number | null = null;
+
+  const sync = (): void => {
+    if (disposed) return;
+    const wanted = options.isEligible();
+    if (wanted && !mounted) {
+      mounted = true;
+      options.mount();
+    } else if (!wanted && mounted) {
+      mounted = false;
+      options.unmount();
+    }
+  };
+
+  sync();
+  const stopRouteWatch = options.watchRoute(sync);
+  const observer = new MutationObserver(() => {
+    if (settleTimer !== null) return;
+    settleTimer = window.setTimeout(() => {
+      settleTimer = null;
+      sync();
+    }, settleMs);
+  });
+  observer.observe(options.root, { childList: true, subtree: true });
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    stopRouteWatch();
+    observer.disconnect();
+    if (settleTimer !== null) {
+      window.clearTimeout(settleTimer);
+      settleTimer = null;
+    }
+    if (mounted) {
+      mounted = false;
+      options.unmount();
+    }
+  };
+}

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -34,6 +34,7 @@ import { resolveExportErrorMessage } from '../../../features/export/ui/ExportErr
 import { showExportToast } from '../../../features/export/ui/ExportToast';
 import { isServerTurnId } from '../fork/turnId';
 import { historyTimestampStore } from '../timestamp/historyTimestamps';
+import { watchRouteChanges } from '../utils/routeWatcher';
 import { ExportPlatformAdapter, resolveExportAdapter } from './adapter/platformAdapters';
 import { assistantHasCanvasDoc, extractAllCanvasDocs, isAnyCanvasOpen } from './canvasDocExtractor';
 import {
@@ -47,6 +48,7 @@ import {
   injectResponseMenuExportButton,
 } from './conversationMenuInjection';
 import { withExportCollectingBanner } from './exportCollectingBanner';
+import { startExportEntryGate } from './exportEntryGate';
 import { resolveExportLogoAnchor } from './exportLogoAnchor';
 import {
   type PendingExportState,
@@ -2416,12 +2418,39 @@ export async function startExportButton(
 
   // Platforms without Gemini's logo/menu UI: mount the persistent toolbar directly.
   if (!exportAdapter.shouldPreloadHistory()) {
-    const toolbarHandle = mountPersistentExportToolbar({
-      label: t('pm_export'),
-      tooltip: t('exportChatJson'),
-      onClick: () => void showExportDialog(dict, lang, { signal: options.signal }),
-    });
-    toolbarHandle.root.setAttribute('data-gv-platform', exportAdapter.site.id);
+    let toolbarHandle: ReturnType<typeof mountPersistentExportToolbar> | null = null;
+    const mountToolbar = () => {
+      toolbarHandle = mountPersistentExportToolbar({
+        label: t('pm_export'),
+        tooltip: t('exportChatJson'),
+        onClick: () => void showExportDialog(dict, lang, { signal: options.signal }),
+      });
+      toolbarHandle.root.setAttribute('data-gv-platform', exportAdapter.site.id);
+    };
+    const unmountToolbar = () => {
+      cancelActiveExportOperation();
+      toolbarHandle?.remove();
+      toolbarHandle = null;
+      activeExportDialog?.hide();
+      activeExportDialog = null;
+    };
+    // A host whose chat UI shares the origin with unrelated pages only gets
+    // the entry point where a conversation can exist, and loses it again when
+    // the SPA navigates away from one.
+    const isConversationPage = exportAdapter.isConversationPage;
+    let stopEntryGate: () => void;
+    if (isConversationPage) {
+      stopEntryGate = startExportEntryGate({
+        isEligible: () => isConversationPage(document, location.href),
+        mount: mountToolbar,
+        unmount: unmountToolbar,
+        watchRoute: watchRouteChanges,
+        root: document.body,
+      });
+    } else {
+      mountToolbar();
+      stopEntryGate = unmountToolbar;
+    }
     const onStorageChange = (
       changes: Record<string, chrome.storage.StorageChange>,
       area: string,
@@ -2431,7 +2460,7 @@ export async function startExportButton(
       if (typeof nextRaw === 'string') {
         const next = normalizeLang(nextRaw);
         lang = next;
-        toolbarHandle.setText(
+        toolbarHandle?.setText(
           dict[next]?.['pm_export'] ?? dict.en?.['pm_export'] ?? 'Export',
           dict[next]?.['exportChatJson'] ?? dict.en?.['exportChatJson'] ?? 'Export chat history',
         );
@@ -2441,13 +2470,10 @@ export async function startExportButton(
       chrome.storage?.onChanged?.addListener(onStorageChange);
     } catch {}
     return () => {
-      cancelActiveExportOperation();
-      toolbarHandle.remove();
+      stopEntryGate();
       try {
         chrome.storage?.onChanged?.removeListener(onStorageChange);
       } catch {}
-      activeExportDialog?.hide();
-      activeExportDialog = null;
     };
   }
 


### PR DESCRIPTION
## Problem

The ChatGPT export plugin matches the whole origin, so its persistent "Export" toolbar also appeared on Codex, settings and library pages such as `https://chatgpt.com/codex/cloud/settings/analytics#code-review`, and stayed there as the SPA moved between such pages and chats.

## Change

- Export adapters may declare `isConversationPage(doc, url)`.
- New `startExportEntryGate` keeps the entry point mounted only while that returns true. It re-checks on route changes (existing `watchRouteChanges`) and on settled DOM mutations, and tears down an in-flight export when the page stops qualifying.
- ChatGPT: a conversation is a `/c/<id>` route (optionally under `/u/<n>/` or `/g/<gpt>/`) or a rendered turn, because a temporary chat keeps `/?temporary-chat=true` while it runs.
- Gemini's path is untouched. Regression note under providers-plugins.

## Verification

- `bun run test src/pages/content/export` (21 files, 175 tests, 6 new), `bun run typecheck`, `bun run lint:check`, `bun run regressions:check`, `bun run build:chrome`.
- Live: no toolbar on the Codex settings page; toolbar on `/c/<id>`; clicking "New chat" removes it and browser back brings it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVUBXiVusYPrQa54FsffLG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to ChatGPT export UI mount timing and cleanup on navigation; no auth, data, or export extraction logic changes.
> 
> **Overview**
> Fixes the ChatGPT persistent export toolbar appearing on same-origin non-chat pages (Codex, settings, library) and persisting across SPA navigation.
> 
> Export adapters can now optionally implement **`isConversationPage(doc, url)`**. **`startExportEntryGate`** mounts the entry point only while that check passes, re-evaluating on route changes and after a settled DOM mutation burst (for temporary chats that stay on `/?temporary-chat=true` while turns render). Leaving an eligible page **unmounts** the toolbar and tears down active export UI via **`cancelActiveExportOperation`** and dialog hide.
> 
> ChatGPT wires **`chatgptIsConversationPage`**: conversation **`/c/<id>`** paths (with optional **`/u/`** or **`/g/`** prefixes) or any page with a rendered turn in the DOM. Platforms without this hook behave as before (toolbar mounts immediately). Regression notes and unit tests cover the gate and URL/DOM rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a40909815e0faf8c288721d613cfa434df8a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The export toolbar now appears only on conversation pages, preventing it from showing on settings, library, Codex, and other unrelated pages.
  * The toolbar updates correctly as users navigate between conversations and other sections.
  * Temporary chats and conversations that appear without a route change are now detected correctly.
  * The toolbar is removed promptly when leaving a conversation and restored when returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->