### PR TITLE
docs(skills): teach create-voyager-plugin the gates the plugin stack added

### DIFF
--- a/.agents/skills/create-voyager-plugin/SKILL.md
+++ b/.agents/skills/create-voyager-plugin/SKILL.md
@@ -2,7 +2,7 @@
 name: create-voyager-plugin
 description: Build a Voyager plugin, a site adapter change, or a primitive, from picking the right path to the evidence a PR must carry. Use for "写一个插件", "add a plugin for <site>", a selector fix in site.json, a new native primitive under verbs/, or any change under src/features/plugins/catalog, verbs or sites.
 metadata:
-  version: '1.0.0'
+  version: '1.1.0'
 ---
 
 # Create a Voyager plugin
@@ -92,8 +92,10 @@ bun run verify:pr
 ```
 
 `plugin:check` is the gate: manifest, CSS, site containment, primitive handlers
-and the engine floor, semantic keys, ten-locale metadata, README presence. Fix
-what it reports rather than arguing with it.
+and the engine floor, semantic keys, selector syntax, the regex subset,
+ten-locale metadata, README presence. It only accepts a directory under
+`catalog/sites/<site>/plugins/`. Fix what it reports rather than arguing with
+it.
 
 ### (b) Site adapter change
 
@@ -101,7 +103,10 @@ Edit `catalog/sites/<site>/site.json` and nothing else; the TypeScript adapters
 for plugin platforms are one-line shells over the JSON. Only keys from
 `src/features/plugins/sites/semanticKeys.ts` are accepted, and a key the site
 cannot honestly provide is **left out**, not filled with a guess: a wrong
-selector fails silently on every plugin that trusts it. Widening `matches`
+selector fails silently on every plugin that trusts it, while a plugin that
+names a key the site leaves out shows `needs-semantic` in the popup, which is
+the honest outcome. Every selector must parse; the site file's validation
+rejects one that does not before it can throw in the page. Widening `matches`
 widens every plugin under that site, so recheck each one still stays inside it.
 
 A new site also needs its directory, a `CODEOWNERS` line, and an extension
@@ -182,7 +187,16 @@ in both themes without opening a browser themselves.
   `{ "kind": "semantic", "key": "userTurn" }`. Raw selectors are for what the
   vocabulary cannot name, and they are the first thing to break on a redesign.
 - A plugin's `matches` stays inside its site's `matches` (D18).
-  `catalog:build` fails otherwise.
+  `catalog:build` fails otherwise. Patterns are read as Chrome reads them:
+  `*.example.com` needs a subdomain (the apex host is outside it) and `*://`
+  means http or https only; the build and the runtime agree, so a pattern that
+  passes the build also resolves a site.
+- `conversationIdPattern`, in `site.json` or as a `turnNavigator` param, is a
+  plain anchored capture such as `^/c/([^/?#]+)`: no lookarounds or
+  backreferences, no repeated group that holds a quantifier or `|`, at most
+  eight quantifiers and 200 characters. It runs on the page's main thread
+  against every URL, so the gate (`sites/safeRegex.ts`) refuses anything that
+  can backtrack.
 - `requires.handlers` lists every primitive the plugin invokes, and `engine`'s
   minimum is at least each primitive's `sinceEngine`. That ordering is the
   point: an old build then says "update Voyager" (`needs-engine`) instead of


### PR DESCRIPTION
## Why

The plugin-distribution stack (#998–#1003) changed what `plugin:check` and `catalog:build` enforce, and the skill an agent loads to author a plugin still described the old gate.

## What

`.agents/skills/create-voyager-plugin/SKILL.md` (version 1.1.0):

- The gate list now names selector syntax, the safe regex subset and the `catalog/sites/<site>/plugins/` layout requirement.
- Site adapter step: every selector must parse; a plugin naming a semantic key the site leaves out shows `needs-semantic`.
- Rules: match patterns are read as Chrome reads them (`*.example.com` needs a subdomain, `*://` is http/https only); `conversationIdPattern` is a plain anchored capture within the subset `sites/safeRegex.ts` enforces (no lookarounds/backreferences, no repeated group holding a quantifier or `|`, at most eight quantifiers, 200 characters).

Prose only; `prettier --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVUBXiVusYPrQa54FsffLG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill file; no runtime or build behavior is modified.
> 
> **Overview**
> Bumps the **create-voyager-plugin** agent skill to **1.1.0** so it matches enforcement added by the plugin-distribution stack (#998–#1003).
> 
> **`plugin:check`** is documented as also validating selector syntax, the allowed regex subset, and requiring paths under `catalog/sites/<site>/plugins/`.
> 
> **Site adapter** guidance now covers parse-time selector validation, the honest **`needs-semantic`** popup when a plugin references a semantic key the site omits, and clarifies wrong vs missing selectors.
> 
> **PR rules** add how Chrome reads **`matches`** (`*.example.com` vs apex, `*://` scope) and constraints on **`conversationIdPattern`** (anchored capture, no lookarounds/backreferences, limits enforced by `sites/safeRegex.ts` because patterns run on the main thread).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5167488d0e4505f044a5663885531bc788421610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the create-voyager-plugin guidance to clarify validation requirements for selector syntax, supported regular expressions, and README presence.
  - Documented a `needs-semantic` outcome for site adapters when required keys are missing.
  - Added guidance for validating match patterns and restricting conversation ID patterns to safe, supported syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->